### PR TITLE
Add endpoint for company orders with destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,21 @@ Use these steps to clone from SourceTree, our client for using the repository co
 4. Open the directory you just created to see your repository’s files.
 
 Now that you're more familiar with your Bitbucket repository, go ahead and add a new file locally. You can [push your change back to Bitbucket with SourceTree](https://confluence.atlassian.com/x/iqyBMg), or you can [add, commit,](https://confluence.atlassian.com/x/8QhODQ) and [push from the command line](https://confluence.atlassian.com/x/NQ0zDQ).
+
+### GET /apiv3/ordenes/byEmpresaPeriodoConDestinos/:idEmpresa/:fechaDesde/:fechaHasta
+
+Obtiene las órdenes de una empresa dentro de un período incluyendo información del destino y de los productos.
+
+Ejemplo de respuesta:
+
+```json
+[
+  {
+    "IdOrden": 1,
+    "Numero": "100",
+    "NombreDestino": "Casa Central",
+    "Barcode": "PROD1",
+    "Unidades": 10
+  }
+]
+```

--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -554,8 +554,45 @@ export const ordenes_getByEmpresa_DALC = async (id: number) => {
 
     return result
 }
-    
+
 ;
+
+export const ordenes_getByEmpresaPeriodoConDestinos_DALC = async (
+    idEmpresa: number,
+    fechaDesde: string,
+    fechaHasta: string
+) => {
+    fechaDesde += " 00:00:00";
+    fechaHasta += " 23:59:59";
+
+    const results = await createQueryBuilder("ordenes", "ord")
+        .select([
+            "ord.Id as IdOrden",
+            "ord.Numero as Numero",
+            "ord.Fecha as Fecha",
+            "des.Nombre as NombreDestino",
+            "des.direccion as DomicilioDestino",
+            "des.postal as CodigoPostalDestino",
+            "des.localidad as LocalidadDestino",
+            "det.Id as IdDetalle",
+            "det.Unidades as Unidades",
+            "prod.Id as IdProducto",
+            "prod.barrcode as Barcode",
+            "prod.Descripcion as NombreProducto",
+        ])
+        .innerJoin("destinos", "des", "des.id = ord.eventual")
+        .innerJoin("orderdetalle", "det", "det.ordenId = ord.Id")
+        .innerJoin("productos", "prod", "prod.id = det.productId")
+        .where("ord.empresa = :idEmpresa", { idEmpresa })
+        .andWhere("ord.fecha BETWEEN :fechaDesde AND :fechaHasta", {
+            fechaDesde,
+            fechaHasta,
+        })
+        .orderBy("ord.fecha", "ASC")
+        .execute();
+
+    return results;
+}
 
 // Devuelve la ultima Orden de una Empresa por el Id
 export const ordenes_getLastByEmpresa_DALC = async (id: number) => {

--- a/src/api/docs/documentacionApi.ts
+++ b/src/api/docs/documentacionApi.ts
@@ -81,3 +81,40 @@ const router=Router()
  *                          $ref: '#components/schema/Error'
  */
 router.get("/apiv3/guia/:guia/:token")
+
+/**
+ * @openapi
+ * /apiv3/ordenes/byEmpresaPeriodoConDestinos/{idEmpresa}/{fechaDesde}/{fechaHasta}:
+ *   get:
+ *     tags:
+ *       - Ordenes
+ *     summary: Lista ordenes de una empresa y rango de fechas con detalles de destino y productos
+ *     parameters:
+ *       - name: idEmpresa
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - name: fechaDesde
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: fechaHasta
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ *         content:
+ *           application/json:
+ *             example:
+*               - IdOrden: 1
+*                 Numero: "100"
+*                 NombreDestino: "Casa Central"
+*                 Barcode: "PROD1"
+*                 Unidades: 10
+*/
+router.get("/apiv3/ordenes/byEmpresaPeriodoConDestinos/:idEmpresa/:fechaDesde/:fechaHasta")

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -6,6 +6,7 @@ import {
     orden_generarNueva,
     orden_informarEmisionEtiqueta,
     ordenes_getByEmpresa_DALC,
+    ordenes_getByEmpresaPeriodoConDestinos_DALC,
     ordenes_getPreparadasNoGuias_DALC,
     orden_marcarComoRetiraCliente,
     orden_anular,
@@ -297,6 +298,20 @@ export const getCantByPeriodoEmpresa = async (req: Request, res: Response): Prom
     }
 
     const result = await ordenes_getCantPeriodoEmpresa_DALC(req.params.fechaDesde, req.params.fechaHasta, empresa.Id)
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result))
+}
+
+export const getByEmpresaPeriodoConDestinos = async (req: Request, res: Response): Promise<Response> => {
+    const empresa = await empresa_getById_DALC(Number(req.params.idEmpresa))
+    if (!empresa) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Empresa inexistente"))
+    }
+
+    const result = await ordenes_getByEmpresaPeriodoConDestinos_DALC(
+        empresa.Id,
+        req.params.fechaDesde,
+        req.params.fechaHasta
+    )
     return res.json(require("lsi-util-node/API").getFormatedResponse(result))
 }
 

--- a/src/routes/ordenes.routes.ts
+++ b/src/routes/ordenes.routes.ts
@@ -19,6 +19,7 @@ import {
     getBultosByIdOrden,
     getCantByPeriodo,
     getCantByPeriodoEmpresa,
+    getByEmpresaPeriodoConDestinos,
     getPendientes,
     setEstado,
     getByNumeroAnIdEmpresa,
@@ -52,6 +53,7 @@ router.get(prefixAPI+"/ordenes/byPeriodoEmpresa/:fechaDesde/:fechaHasta/:idEmpre
 router.get(prefixAPI+"/ordenes/getOrdenDetalleByIdProducto/:idProducto", getOrdenDetalleByIdProducto)
 router.get(prefixAPI+"/ordenes/byPeriodoEmpresaSoloPreparadasYNoPreorden/:fechaDesde/:fechaHasta/:idEmpresa", getByPeriodoEmpresaSoloPreparadasYNoPreorden)
 router.get(prefixAPI+"/ordenes/getCantByPeriodoEmpresa/:fechaDesde/:fechaHasta/:idEmpresa", getCantByPeriodoEmpresa)
+router.get(prefixAPI+"/ordenes/byEmpresaPeriodoConDestinos/:idEmpresa/:fechaDesde/:fechaHasta", getByEmpresaPeriodoConDestinos)
 router.get(prefixAPI+"/ordenes/get/preparadasNoGuias", getPreparadasNoGuias)
 router.get(prefixAPI+"/ordenes/get/preparadasNoGuiasByIdEmpresa/:idEmpresa", getPreparadasNoGuiasByIdEmpresa)
 router.get(prefixAPI+"/ordenes/getPendientes", getPendientes)
@@ -77,8 +79,5 @@ router.put(prefixAPI+"/ordenes/editCantidadImpresion/:orden/:impresion", editCan
 router.delete(prefixAPI+"/orden/deleteOneById/:id", eliminarOrden)
 
 router.get(`${prefixAPI}/ordenes/byIdEmpresa/:idEmpresa`, ordenesByEmpresaId)
-
-
-
 
 export default router


### PR DESCRIPTION
## Summary
- implement `ordenes_getByEmpresaPeriodoConDestinos_DALC` using query builder
- add controller and routing for `/ordenes/byEmpresaPeriodoConDestinos/...`
- document new endpoint in API docs and README

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6849e792a384832ab8fdc2a71a430d7c