### PR TITLE
Implement order status history logging

### DIFF
--- a/src/DALC/ordenEstadoHistorico.dalc.ts
+++ b/src/DALC/ordenEstadoHistorico.dalc.ts
@@ -1,0 +1,18 @@
+import { getRepository } from "typeorm"
+import { OrdenEstadoHistorico } from "../entities/OrdenEstadoHistorico"
+
+export const ordenEstadoHistorico_insert_DALC = async (idOrden: number, estado: number, usuario: string, fecha: Date) => {
+    const nuevo = new OrdenEstadoHistorico()
+    nuevo.IdOrden = idOrden
+    nuevo.Estado = estado
+    nuevo.Usuario = usuario
+    nuevo.Fecha = fecha
+    const registro = getRepository(OrdenEstadoHistorico).create(nuevo)
+    const result = await getRepository(OrdenEstadoHistorico).save(registro)
+    return result
+}
+
+export const ordenEstadoHistorico_getByIdOrden_DALC = async (idOrden: number) => {
+    const results = await getRepository(OrdenEstadoHistorico).find({where: {IdOrden: idOrden}, order: {Fecha: "ASC"}})
+    return results
+}

--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -15,6 +15,7 @@ import { createMovimientosStock_DALC } from "./movimientos.dalc"
 import { posicion_getById_DALC } from "./posiciones.dalc"
 import { ordenDetallePosiciones_getByIdOrdenAndIdEmpresa_DALC, ordenDetalle_getByIdOrdenAndProductoAndPartida_DALC, ordenDetalle_getByIdOrdenAndProducto_DALC, ordenDetalle_getByIdOrden_DALC, ordenDetalle_getByIdProducto_DALC } from "./ordenesDetalle.dalc"
 import { Lote } from "../entities/Lote"
+import { ordenEstadoHistorico_insert_DALC } from "./ordenEstadoHistorico.dalc"
 
 
 export const orden_getDetalleByOrden = async (orden: Orden) => {
@@ -44,6 +45,7 @@ export const orden_informarEmisionEtiqueta = async (orden: Orden) => {
 export const orden_anular = async (orden: Orden) => {
     orden.Estado=4
     const result=await getRepository(Orden).save(orden)
+    await ordenEstadoHistorico_insert_DALC(orden.Id, 4, orden.Usuario ? orden.Usuario : "", new Date())
     return result
 }
 
@@ -61,7 +63,8 @@ export const orden_anular_by_id = async ( usuario: string,IdOrden: string, numer
         }
     }
     const result=await getRepository(Orden).update(IdOrden,{Estado: 4,Usuario: usuario,Numero:nombreOrden})
-    return result 
+    await ordenEstadoHistorico_insert_DALC(Number(IdOrden), 4, usuario, new Date())
+    return result
 }
 
 export const orden_setPreorden_DALC = async (orden: Orden, preOrden: boolean, fecha: string, usuario: string) => {
@@ -326,6 +329,9 @@ export const orden_generarNueva = async (empresa: Empresa, detalle: any[], compr
         
         const resultToSave=getRepository(Orden).create(nuevaOrden)
         const nuevaOrdenCreada=await getRepository(Orden).save(resultToSave)
+        if (nuevaOrdenCreada) {
+            await ordenEstadoHistorico_insert_DALC(nuevaOrdenCreada.Id, nuevaOrdenCreada.Estado, usuario, new Date())
+        }
         if (nuevaOrdenCreada==null) {
             errores.push("La nueva orden no pudo ser creada")
         }
@@ -381,6 +387,7 @@ export const orden_marcarComoRetiraCliente = async (orden: Orden, fecha: string)
     orden.Fecha=fecha
     orden.Estado=5
     const result=await getRepository(Orden).save(orden)
+    await ordenEstadoHistorico_insert_DALC(orden.Id, 5, orden.Usuario ? orden.Usuario : "", new Date())
     return result
 }
 
@@ -585,10 +592,11 @@ export const ordenes_addOrden_DALC = async(orden:object) => {
     
 }
 
-export const orden_editEstado_DALC = async (orden: Orden, estado: number) => {
-    
+export const orden_editEstado_DALC = async (orden: Orden, estado: number, usuario: string) => {
+
         orden.Estado=estado
         const result=await getRepository(Orden).save(orden)
+        await ordenEstadoHistorico_insert_DALC(orden.Id, estado, usuario, new Date())
         return result
     
 }
@@ -773,7 +781,7 @@ export const ordenes_SalidaOrdenes_DALC = async (body: any) => {
                                 if(result?.status == 'OK'){
                                       const movimiento = await createMovimientosStock_DALC({Orden: comprobante, IdProducto: unRegistro.IdProducto, Unidades: parseInt(unRegistro.Cantidad), Tipo: 1, IdEmpresa: parseInt(idEmpresa), fecha: new Date(), codprod: unRegistro.Barcode, Usuario: usuario,  Lote: unRegistro.Lote})    
                                     if(orden){ 
-                                        await orden_editEstado_DALC(orden, 2)
+                                        await orden_editEstado_DALC(orden, 2, usuario)
                                         await orden_datosPreparado_DALC(orden, fecha, usuario) 
                                     }                            
                                 } else {
@@ -820,7 +828,7 @@ export const ordenes_SalidaOrdenes_DALC = async (body: any) => {
                                             const movimiento = await createMovimientosStock_DALC({Orden: comprobante, IdProducto: unRegistro.idPartida, Unidades: parseInt(unRegistro.Cantidad), Tipo: 1, IdEmpresa: parseInt(idEmpresa), fecha: new Date(), codprod: producto[0].Partida, Usuario: usuario })    
                                             
                                             if(orden){ 
-                                                await orden_editEstado_DALC(orden, 2)
+                                                await orden_editEstado_DALC(orden, 2, usuario)
                                                 await orden_datosPreparado_DALC(orden, fecha, usuario)  
                                             }                            
                                         }  
@@ -885,7 +893,7 @@ export const ordenes_SalidaOrdenes_DALC = async (body: any) => {
                                 });
             
                                 if (orden) {
-                                    await orden_editEstado_DALC(orden, 2);
+                                    await orden_editEstado_DALC(orden, 2, usuario);
                                     await orden_datosPreparado_DALC(orden, fecha, usuario);
                                 }
                             }
@@ -907,7 +915,7 @@ export const ordenes_SalidaOrdenes_DALC = async (body: any) => {
                                 Usuario: usuario
                             });
                             if (orden) {
-                                await orden_editEstado_DALC(orden, 2);
+                                await orden_editEstado_DALC(orden, 2, usuario);
                                 await orden_datosPreparado_DALC(orden, fecha, usuario);
                             }
                         }

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -28,6 +28,7 @@ import {
      contador_bultos_dia_DLAC,
      getProductosYPosicionesByOrden_DALC
 } from '../DALC/ordenes.dalc'
+import { ordenEstadoHistorico_getByIdOrden_DALC } from '../DALC/ordenEstadoHistorico.dalc'
 import { bultos_setByIdOrdenAndIdEmpresa,
          ordenDetalle_getByIdOrden_DALC,
          ordenDetalle_delete_DALC,
@@ -367,7 +368,7 @@ export const setEstado = async (req: Request, res: Response): Promise <Response>
         return res.json(require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente"))
     }
 
-    const result = await orden_editEstado_DALC(orden, Number(req.params.estado))
+    const result = await orden_editEstado_DALC(orden, Number(req.params.estado), "")
     return res.json(require("lsi-util-node/API").getFormatedResponse(result))
 }
 
@@ -396,4 +397,9 @@ export const eliminarOrden = async (req: Request, res: Response): Promise <Respo
     const results = await orden_delete_DALC(Number(req.params.id))
     const results2 = await ordenDetalle_delete_DALC(Number(req.params.id))
     return res.json(require("lsi-util-node/API").getFormatedResponse(results+". "+results2))
+}
+
+export const getHistoricoEstadosOrden = async (req: Request, res: Response): Promise<Response> => {
+    const result = await ordenEstadoHistorico_getByIdOrden_DALC(Number(req.params.idOrden))
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result))
 }

--- a/src/entities/OrdenEstadoHistorico.ts
+++ b/src/entities/OrdenEstadoHistorico.ts
@@ -1,0 +1,19 @@
+import {Entity, Column, PrimaryGeneratedColumn} from "typeorm"
+
+@Entity("ordenes_estados_historico")
+export class OrdenEstadoHistorico {
+    @PrimaryGeneratedColumn()
+    Id: number
+
+    @Column({name: "ordenId"})
+    IdOrden: number
+
+    @Column()
+    Estado: number
+
+    @Column()
+    Usuario: string
+
+    @Column()
+    Fecha: Date
+}

--- a/src/routes/ordenes.routes.ts
+++ b/src/routes/ordenes.routes.ts
@@ -34,7 +34,8 @@ import {
     getPreparadasNoGuiasByIdEmpresa,
     contadorBultosDia,
     getDetalleOrdenAndProductoAndPartidaById,
-    getProductosYPosicionesByOrden
+    getProductosYPosicionesByOrden,
+    getHistoricoEstadosOrden
 } from "../controllers/ordenes.controller"
 
 const prefixAPI="/apiv3"
@@ -58,6 +59,7 @@ router.get(prefixAPI+"/ordenes/getPendientes", getPendientes)
 router.get(prefixAPI+"/ordenes/getOrdenes", getOrdenes)
 router.get(prefixAPI+"/ordenes/contadorBultosDia/:idEmpresa/:fecha", contadorBultosDia)
 router.get("/apiv3/ordenes/productos-posiciones/:idOrden", getProductosYPosicionesByOrden);
+router.get(prefixAPI+"/ordenes/historico/:idOrden", getHistoricoEstadosOrden)
 
 
 router.post(prefixAPI+"/orden", generarNueva)


### PR DESCRIPTION
## Summary
- add `OrdenEstadoHistorico` entity
- support saving and listing order status history
- log history from order DALC functions
- expose controller and route to view order history

## Testing
- `npm run build` *(fails: Cannot find module 'express' or corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6849e791a364832abaccc98805e5d2c8