### PR TITLE
Add guia state history tracking

### DIFF
--- a/src/DALC/guiasEstadoHistorico.dalc.ts
+++ b/src/DALC/guiasEstadoHistorico.dalc.ts
@@ -1,0 +1,18 @@
+import { getRepository } from "typeorm"
+import { GuiaEstadoHistorico } from "../entities/GuiaEstadoHistorico"
+
+export const insertGuiaEstadoHistorico = async (idGuia: number, estado: string, usuario: string, fecha: Date) => {
+    const nuevo = new GuiaEstadoHistorico()
+    nuevo.IdGuia = idGuia
+    nuevo.Estado = estado
+    nuevo.Usuario = usuario
+    nuevo.Fecha = fecha
+    const registro = getRepository(GuiaEstadoHistorico).create(nuevo)
+    const result = await getRepository(GuiaEstadoHistorico).save(registro)
+    return result
+}
+
+export const guiaEstadoHistorico_getByIdGuia_DALC = async (idGuia: number) => {
+    const results = await getRepository(GuiaEstadoHistorico).find({where: {IdGuia: idGuia}, order: {Fecha: "ASC"}})
+    return results
+}

--- a/src/DALC/guias_DALC.ts
+++ b/src/DALC/guias_DALC.ts
@@ -17,6 +17,7 @@ import { mailSaliente_send_DALC } from "./mailSaliente.dalc"
 import { orden_getDetalleByOrden } from "./ordenes.dalc"
 import { producto_getById_DALC } from "./productos.dalc"
 import { Usuario } from "../entities/Usuario"
+import { insertGuiaEstadoHistorico } from "./guiasEstadoHistorico.dalc"
 
 
 //select * from planchada where guia in (948888, 949285, 949286, 949287, 949288, 949289, 949290, 949291, 949292, 949293, 949294, 949295, 949296, 949500, 949501, 949502, 949503, 949504, 949505, 949506, 949507, 949508, 949509, 949510, 949807, 949879, 949880, 949881, 949882, 949883, 949884, 949885, 949886, 949887, 949888, 949889, 949890, 949891, 949892, 949893, 949894, 949895)
@@ -121,9 +122,10 @@ export const guia_registrar_entrega = async (id: number, idChofer: number, fecha
     guiaAActualizar.Estado=estado
     //guiaAActualizar.NombreReceptor=nombreReceptor
     const guiaActualizada=await getRepository(Guia).save(guiaAActualizar)
+    await insertGuiaEstadoHistorico(guiaActualizada.Id, estado, "", new Date())
     return guiaActualizada
   } else {
-    return null    
+    return null
   }
 }
 
@@ -151,6 +153,7 @@ export const guias_actualizarFecha = async (fecha: string, idsGuias: string) => 
       const nuevoAtraso=Number(Math.max(0, corrimiento)) + Number(guiaPreviaActualizacion.Atraso)
       // console.log("Nuevo atraso", nuevoAtraso)
       await getRepository(Guia).update(unaId, {Fecha: fecha, Atraso: nuevoAtraso, Estado: "En Planchada", IdChofer: 0})
+      await insertGuiaEstadoHistorico(Number(unaId), "En Planchada", "", new Date())
 
       const guiaActualizadaToSave=new GuiaActualizacion()
       guiaActualizadaToSave.IdGuia=guiaPreviaActualizacion.Id
@@ -244,6 +247,7 @@ export const crearNuevaGuiaDesdeOrden_DALC = async (orden: Orden, destino: Desti
  
   const guiaAGrabar=getRepository(Guia).create(nuevaGuia)
   const result=await getRepository(Guia).save(guiaAGrabar)
+  await insertGuiaEstadoHistorico(result.Id, result.Estado, "", new Date())
 
   getRepository(Guia).update(result.Id, {Comprobante: String(result.Id)})
   result.Comprobante=String(result.Id)

--- a/src/controllers/guias.controller.ts
+++ b/src/controllers/guias.controller.ts
@@ -22,6 +22,8 @@ import {
   guias_getByPeriodoIdEmpresa_DALC
 } from '../DALC/guias_DALC'
 
+import { guiaEstadoHistorico_getByIdGuia_DALC } from '../DALC/guiasEstadoHistorico.dalc'
+
 import {
     set_guiasFotos_new
 } from '../DALC/guiasFotos.dalc'
@@ -377,10 +379,15 @@ export const addFotoEntrega = async (req: Request, res: Response): Promise <Resp
 
 export const getByRemito = async (req: Request, res: Response): Promise <Response> => {
     const Guias = await guia_getRemitos_DALC(Number(req.params.idEmpresa),req.params.idRemito)
-    
+
     if (Guias!=null) {
         return res.json(require("lsi-util-node/API").getFormatedResponse(Guias))
     } else {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Error en obtención de guías"))
     }
+}
+
+export const getHistoricoEstadosGuia = async (req: Request, res: Response): Promise<Response> => {
+    const result = await guiaEstadoHistorico_getByIdGuia_DALC(Number(req.params.idGuia))
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result))
 }

--- a/src/entities/GuiaEstadoHistorico.ts
+++ b/src/entities/GuiaEstadoHistorico.ts
@@ -1,0 +1,19 @@
+import {Entity, Column, PrimaryGeneratedColumn} from "typeorm"
+
+@Entity("guias_estados_historico")
+export class GuiaEstadoHistorico {
+    @PrimaryGeneratedColumn()
+    Id: number
+
+    @Column({name: "guiaId"})
+    IdGuia: number
+
+    @Column()
+    Estado: string
+
+    @Column()
+    Usuario: string
+
+    @Column()
+    Fecha: Date
+}

--- a/src/routes/guias.routes.ts
+++ b/src/routes/guias.routes.ts
@@ -23,7 +23,8 @@ import {
     getByRemito,
     getByGuiaAndToken,
     getByPeriodoEmpresaFecha,
-    getByPeriodoIdEmpresa
+    getByPeriodoIdEmpresa,
+    getHistoricoEstadosGuia
 } from "../controllers/guias.controller"
 
 import {
@@ -42,6 +43,7 @@ router.get(prefixAPI+"/guias/getAllEnPlanchada", getAllEnPlanchada)
 router.get(prefixAPI+"/guias/getPlanchadaByComprobanteAndToken/:comprobante/:token", getPlanchadaByComprobanteAndToken)
 router.get(prefixAPI+"/guias/getRemitos/:idEmpresa/:idRemito", getByRemito)
 router.put(prefixAPI+"/guias/setAllActualizarFecha/:fecha/:idsGuias", setActualizarFecha)
+router.get(prefixAPI+"/guia/historico/:idGuia", getHistoricoEstadosGuia)
 
 router.get(prefixAPI+"/guias/byPeriodoEmpresa/:fechaDesde/:fechaHasta/:idEmpresa", getByPeriodoEmpresa)
 router.get(prefixAPI+"/guias/byPeriodoEmpresa/:fechaDesde/:fechaHasta", getByPeriodoEmpresa)


### PR DESCRIPTION
## Summary
- add GuiaEstadoHistorico entity and DALC
- log state changes in guia DALC functions
- expose endpoint to get guide state history

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a376084ac832a8e26e2187d4fa6fe