### PR TITLE
Add deletion audit log

### DIFF
--- a/src/DALC/ordenAuditoria.dalc.ts
+++ b/src/DALC/ordenAuditoria.dalc.ts
@@ -1,0 +1,18 @@
+import { getRepository } from "typeorm"
+import { OrdenAuditoria } from "../entities/OrdenAuditoria"
+
+export const ordenAuditoria_insert_DALC = async (idOrden: number, accion: string, usuario: string, fecha: Date) => {
+    const nuevo = new OrdenAuditoria()
+    nuevo.IdOrden = idOrden
+    nuevo.Accion = accion
+    nuevo.Usuario = usuario
+    nuevo.Fecha = fecha
+    const registro = getRepository(OrdenAuditoria).create(nuevo)
+    const result = await getRepository(OrdenAuditoria).save(registro)
+    return result
+}
+
+export const ordenAuditoria_getEliminadas_DALC = async () => {
+    const results = await getRepository(OrdenAuditoria).find({ where: { Accion: "ELIMINADA" }, order: { Fecha: "ASC" } })
+    return results
+}

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -26,10 +26,11 @@ import {
      ordenes_SalidaOrdenes_DALC,
      orden_editImpresion_DALC,
      ordenes_getPreparadasNoGuiasByIdEmpresa_DALC,
-     contador_bultos_dia_DLAC,
-     getProductosYPosicionesByOrden_DALC
+    contador_bultos_dia_DLAC,
+    getProductosYPosicionesByOrden_DALC
 } from '../DALC/ordenes.dalc'
 import { ordenEstadoHistorico_getByIdOrden_DALC } from '../DALC/ordenEstadoHistorico.dalc'
+import { ordenAuditoria_insert_DALC, ordenAuditoria_getEliminadas_DALC } from '../DALC/ordenAuditoria.dalc'
 import { bultos_setByIdOrdenAndIdEmpresa,
          ordenDetalle_getByIdOrden_DALC,
          ordenDetalle_delete_DALC,
@@ -409,6 +410,7 @@ export const eliminarOrden = async (req: Request, res: Response): Promise <Respo
     if (!orden) {
         return res.json(require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente"))
     }
+    await ordenAuditoria_insert_DALC(orden.Id, "ELIMINADA", orden.Usuario ? orden.Usuario : "", new Date())
     const results = await orden_delete_DALC(Number(req.params.id))
     const results2 = await ordenDetalle_delete_DALC(Number(req.params.id))
     return res.json(require("lsi-util-node/API").getFormatedResponse(results+". "+results2))
@@ -416,5 +418,10 @@ export const eliminarOrden = async (req: Request, res: Response): Promise <Respo
 
 export const getHistoricoEstadosOrden = async (req: Request, res: Response): Promise<Response> => {
     const result = await ordenEstadoHistorico_getByIdOrden_DALC(Number(req.params.idOrden))
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result))
+}
+
+export const getOrdenesEliminadas = async (_req: Request, res: Response): Promise<Response> => {
+    const result = await ordenAuditoria_getEliminadas_DALC()
     return res.json(require("lsi-util-node/API").getFormatedResponse(result))
 }

--- a/src/entities/OrdenAuditoria.ts
+++ b/src/entities/OrdenAuditoria.ts
@@ -1,0 +1,19 @@
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm"
+
+@Entity("ordenes_auditoria")
+export class OrdenAuditoria {
+    @PrimaryGeneratedColumn()
+    Id: number
+
+    @Column({ name: "ordenId" })
+    IdOrden: number
+
+    @Column()
+    Accion: string
+
+    @Column()
+    Usuario: string
+
+    @Column()
+    Fecha: Date
+}

--- a/src/routes/ordenes.routes.ts
+++ b/src/routes/ordenes.routes.ts
@@ -36,7 +36,8 @@ import {
     contadorBultosDia,
     getDetalleOrdenAndProductoAndPartidaById,
     getProductosYPosicionesByOrden,
-    getHistoricoEstadosOrden
+    getHistoricoEstadosOrden,
+    getOrdenesEliminadas
 } from "../controllers/ordenes.controller"
 
 const prefixAPI="/apiv3"
@@ -62,6 +63,7 @@ router.get(prefixAPI+"/ordenes/getOrdenes", getOrdenes)
 router.get(prefixAPI+"/ordenes/contadorBultosDia/:idEmpresa/:fecha", contadorBultosDia)
 router.get("/apiv3/ordenes/productos-posiciones/:idOrden", getProductosYPosicionesByOrden);
 router.get(prefixAPI+"/ordenes/historico/:idOrden", getHistoricoEstadosOrden)
+router.get(prefixAPI+"/ordenes/eliminadas", getOrdenesEliminadas)
 
 
 router.post(prefixAPI+"/orden", generarNueva)


### PR DESCRIPTION
## Summary
- track deleted orders in `ordenes_auditoria`
- expose DALC helper for insertion and query
- log deletions in `eliminarOrden`
- add endpoint to view deleted orders

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684a3772e980832ab44a52cdf152f915