### PR TITLE
Add auditing table and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ Ejemplo de respuesta:
   }
 ]
 ```
+
+### GET /apiv3/auditoria/:entidad/:idRegistro?
+
+Obtiene registros de auditoría para una entidad y registro opcional.

--- a/src/DALC/auditoria.dalc.ts
+++ b/src/DALC/auditoria.dalc.ts
@@ -1,0 +1,35 @@
+import { getRepository } from "typeorm"
+import { Auditoria } from "../entities/Auditoria"
+
+export const auditoria_insert_DALC = async (
+    entidad: string,
+    idRegistro: number,
+    accion: string,
+    usuario: string,
+    fecha: Date
+) => {
+    const nuevo = new Auditoria()
+    nuevo.Entidad = entidad
+    nuevo.IdRegistro = idRegistro
+    nuevo.Accion = accion
+    nuevo.Usuario = usuario
+    nuevo.Fecha = fecha
+
+    const registro = getRepository(Auditoria).create(nuevo)
+    const result = await getRepository(Auditoria).save(registro)
+    return result
+}
+
+export const auditoria_get_DALC = async (
+    entidad?: string,
+    idRegistro?: number
+) => {
+    const where: any = {}
+    if (entidad) where.Entidad = entidad
+    if (idRegistro !== undefined) where.IdRegistro = idRegistro
+    const results = await getRepository(Auditoria).find({
+        where,
+        order: { Fecha: "DESC" }
+    })
+    return results
+}

--- a/src/DALC/guias_DALC.ts
+++ b/src/DALC/guias_DALC.ts
@@ -17,6 +17,7 @@ import { mailSaliente_send_DALC } from "./mailSaliente.dalc"
 import { orden_getDetalleByOrden } from "./ordenes.dalc"
 import { producto_getById_DALC } from "./productos.dalc"
 import { Usuario } from "../entities/Usuario"
+import { auditoria_insert_DALC } from "./auditoria.dalc"
 
 
 //select * from planchada where guia in (948888, 949285, 949286, 949287, 949288, 949289, 949290, 949291, 949292, 949293, 949294, 949295, 949296, 949500, 949501, 949502, 949503, 949504, 949505, 949506, 949507, 949508, 949509, 949510, 949807, 949879, 949880, 949881, 949882, 949883, 949884, 949885, 949886, 949887, 949888, 949889, 949890, 949891, 949892, 949893, 949894, 949895)
@@ -164,7 +165,8 @@ export const guias_actualizarFecha = async (fecha: string, idsGuias: string) => 
       guiaActualizadaToSave.AtrasoActualizado=nuevoAtraso
 
       const newGuiaActualizada=getRepository(GuiaActualizacion).create(guiaActualizadaToSave)
-      getRepository(GuiaActualizacion).save(newGuiaActualizada)
+      const registro=await getRepository(GuiaActualizacion).save(newGuiaActualizada)
+      await auditoria_insert_DALC("Guia", guiaPreviaActualizacion.Id, "ACTUALIZAR_FECHA", "", new Date())
     }
 
 

--- a/src/DALC/ordenEstadoHistorico.dalc.ts
+++ b/src/DALC/ordenEstadoHistorico.dalc.ts
@@ -1,5 +1,6 @@
 import { getRepository } from "typeorm"
 import { OrdenEstadoHistorico } from "../entities/OrdenEstadoHistorico"
+import { auditoria_insert_DALC } from "./auditoria.dalc"
 
 export const ordenEstadoHistorico_insert_DALC = async (idOrden: number, estado: number, usuario: string, fecha: Date) => {
     const nuevo = new OrdenEstadoHistorico()
@@ -9,6 +10,7 @@ export const ordenEstadoHistorico_insert_DALC = async (idOrden: number, estado: 
     nuevo.Fecha = fecha
     const registro = getRepository(OrdenEstadoHistorico).create(nuevo)
     const result = await getRepository(OrdenEstadoHistorico).save(registro)
+    await auditoria_insert_DALC("Orden", idOrden, "CAMBIO_ESTADO", usuario, fecha)
     return result
 }
 

--- a/src/DALC/productos.dalc.ts
+++ b/src/DALC/productos.dalc.ts
@@ -2,6 +2,7 @@ import {getRepository, createQueryBuilder, Any} from "typeorm"
 import {Producto} from "../entities/Producto"
 import {PosicionProducto} from '../entities/PosicionProducto'
 import {HistoricoPosiciones} from '../entities/HistoricoPosiciones'
+import { auditoria_insert_DALC } from "./auditoria.dalc"
 import {posicion_getById_DALC,posicion_getByIdProd_DALC,posicion_getAllByIdProd_DALC} from "../DALC/posiciones.dalc"
 import { Posicion } from "../entities/Posicion"
 import { ProductoPosicionado } from "../interfaces/ProductoPosicionado"
@@ -612,9 +613,9 @@ export const producto_SaveHistoricoDePosicion_DALC =  async (idProducto: number,
     salidaDePosicion.Usuario = usuario
 
     const registroSalida=getRepository(HistoricoPosiciones).create(salidaDePosicion)
-    let result=await getRepository(HistoricoPosiciones).save(registroSalida)
-
-
+    const result=await getRepository(HistoricoPosiciones).save(registroSalida)
+    await auditoria_insert_DALC("Producto", idProducto, "CAMBIO_POSICION", usuario, salidaDePosicion.Fecha)
+    return result
 }
 
 export const producto_editByBarcodeAndEmpresa_DALC = async ( barcode: string, idEmpresa: number, propiedades:any) => {

--- a/src/controllers/auditoria.controller.ts
+++ b/src/controllers/auditoria.controller.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from "express"
+import { auditoria_get_DALC } from "../DALC/auditoria.dalc"
+
+export const getAuditoria = async (req: Request, res: Response): Promise<Response> => {
+    const entidad = req.params.entidad
+    const idRegistro = req.params.idRegistro ? Number(req.params.idRegistro) : undefined
+    const result = await auditoria_get_DALC(entidad, idRegistro)
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result))
+}

--- a/src/entities/Auditoria.ts
+++ b/src/entities/Auditoria.ts
@@ -1,0 +1,22 @@
+import {Entity, Column, PrimaryGeneratedColumn} from "typeorm"
+
+@Entity("auditoria")
+export class Auditoria {
+    @PrimaryGeneratedColumn()
+    Id: number
+
+    @Column()
+    Entidad: string
+
+    @Column({name: "id_registro"})
+    IdRegistro: number
+
+    @Column()
+    Accion: string
+
+    @Column()
+    Usuario: string
+
+    @Column()
+    Fecha: Date
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import visionGoogle from './routes/visionGoogle.routes';
 import usuarios from './routes/usuarios.routes';
 import destinos from './routes/destinos.routes';
 import roles from './routes/roles.routes';
+import auditoriaRoutes from './routes/auditoria.routes';
 
 import tiendaNubeRoutes from "./api/tiendanube/routes/tiendanube.routes";
 import yiqiRoutes from "./api/yiqi/routes/yiqi.routes";
@@ -63,6 +64,7 @@ app.use(visionGoogle)
 app.use(usuarios)
 app.use(destinos)
 app.use(roles)
+app.use(auditoriaRoutes)
 
 
 // Rutas de Integraciones con APIS

--- a/src/routes/auditoria.routes.ts
+++ b/src/routes/auditoria.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+const router = Router()
+
+import { getAuditoria } from "../controllers/auditoria.controller"
+
+const prefixAPI = "/apiv3"
+
+router.get(`${prefixAPI}/auditoria/:entidad/:idRegistro?`, getAuditoria)
+
+export default router


### PR DESCRIPTION
## Summary
- create `Auditoria` entity and DALC helper
- log product, order, and guide history actions in auditing table
- expose audit query route
- document the new audit endpoint

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a378421c8832a91cb1e09c11c132f