### PR TITLE
Add auditing table support

### DIFF
--- a/src/DALC/auditoria.dalc.ts
+++ b/src/DALC/auditoria.dalc.ts
@@ -1,0 +1,30 @@
+import { getRepository } from "typeorm"
+import { Auditoria } from "../entities/Auditoria"
+
+export const auditoria_insert_DALC = async (
+    entidad: string,
+    idRegistro: number,
+    accion: string,
+    usuario: string,
+    fecha: Date
+) => {
+    const nuevo = new Auditoria()
+    nuevo.Entidad = entidad
+    nuevo.IdRegistro = idRegistro
+    nuevo.Accion = accion
+    nuevo.Usuario = usuario
+    nuevo.Fecha = fecha
+    const registro = getRepository(Auditoria).create(nuevo)
+    const result = await getRepository(Auditoria).save(registro)
+    return result
+}
+
+export const auditoria_getByEntidad_DALC = async (entidad: string) => {
+    const results = await getRepository(Auditoria).find({ where: { Entidad: entidad }, order: { Fecha: "ASC" } })
+    return results
+}
+
+export const auditoria_getByEntidadId_DALC = async (entidad: string, idRegistro: number) => {
+    const results = await getRepository(Auditoria).find({ where: { Entidad: entidad, IdRegistro: idRegistro }, order: { Fecha: "ASC" } })
+    return results
+}

--- a/src/DALC/guiasEstadoHistorico.dalc.ts
+++ b/src/DALC/guiasEstadoHistorico.dalc.ts
@@ -1,5 +1,6 @@
 import { getRepository } from "typeorm"
 import { GuiaEstadoHistorico } from "../entities/GuiaEstadoHistorico"
+import { auditoria_insert_DALC } from "./auditoria.dalc"
 
 export const insertGuiaEstadoHistorico = async (idGuia: number, estado: string, usuario: string, fecha: Date) => {
     const nuevo = new GuiaEstadoHistorico()
@@ -9,6 +10,7 @@ export const insertGuiaEstadoHistorico = async (idGuia: number, estado: string, 
     nuevo.Fecha = fecha
     const registro = getRepository(GuiaEstadoHistorico).create(nuevo)
     const result = await getRepository(GuiaEstadoHistorico).save(registro)
+    await auditoria_insert_DALC("Guia", idGuia, estado, usuario, fecha)
     return result
 }
 

--- a/src/DALC/ordenAuditoria.dalc.ts
+++ b/src/DALC/ordenAuditoria.dalc.ts
@@ -1,5 +1,6 @@
 import { getRepository } from "typeorm"
 import { OrdenAuditoria } from "../entities/OrdenAuditoria"
+import { auditoria_insert_DALC } from "./auditoria.dalc"
 
 export const ordenAuditoria_insert_DALC = async (idOrden: number, accion: string, usuario: string, fecha: Date) => {
     const nuevo = new OrdenAuditoria()
@@ -9,6 +10,7 @@ export const ordenAuditoria_insert_DALC = async (idOrden: number, accion: string
     nuevo.Fecha = fecha
     const registro = getRepository(OrdenAuditoria).create(nuevo)
     const result = await getRepository(OrdenAuditoria).save(registro)
+    await auditoria_insert_DALC("Orden", idOrden, accion, usuario, fecha)
     return result
 }
 

--- a/src/DALC/ordenEstadoHistorico.dalc.ts
+++ b/src/DALC/ordenEstadoHistorico.dalc.ts
@@ -1,5 +1,6 @@
 import { getRepository } from "typeorm"
 import { OrdenEstadoHistorico } from "../entities/OrdenEstadoHistorico"
+import { auditoria_insert_DALC } from "./auditoria.dalc"
 
 export const ordenEstadoHistorico_insert_DALC = async (idOrden: number, estado: number, usuario: string, fecha: Date) => {
     const nuevo = new OrdenEstadoHistorico()
@@ -9,6 +10,7 @@ export const ordenEstadoHistorico_insert_DALC = async (idOrden: number, estado: 
     nuevo.Fecha = fecha
     const registro = getRepository(OrdenEstadoHistorico).create(nuevo)
     const result = await getRepository(OrdenEstadoHistorico).save(registro)
+    await auditoria_insert_DALC("Orden", idOrden, String(estado), usuario, fecha)
     return result
 }
 

--- a/src/DALC/productosHistorico.dalc.ts
+++ b/src/DALC/productosHistorico.dalc.ts
@@ -1,5 +1,6 @@
 import { getRepository } from "typeorm"
 import { ProductoHistorico } from "../entities/ProductoHistorico"
+import { auditoria_insert_DALC } from "./auditoria.dalc"
 
 export const productosHistorico_insert_DALC = async (idProducto: number, accion: string, usuario: string, fecha: Date, detalle: string) => {
     const nuevo = new ProductoHistorico()
@@ -10,6 +11,7 @@ export const productosHistorico_insert_DALC = async (idProducto: number, accion:
     nuevo.Detalle = detalle
     const registro = getRepository(ProductoHistorico).create(nuevo)
     const result = await getRepository(ProductoHistorico).save(registro)
+    await auditoria_insert_DALC("Producto", idProducto, accion, usuario, fecha)
     return result
 }
 

--- a/src/controllers/auditoria.controller.ts
+++ b/src/controllers/auditoria.controller.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from "express"
+import { auditoria_getByEntidad_DALC, auditoria_getByEntidadId_DALC } from "../DALC/auditoria.dalc"
+
+export const getAuditoriaByEntidad = async (req: Request, res: Response): Promise<Response> => {
+    const result = await auditoria_getByEntidad_DALC(req.params.entidad)
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result))
+}
+
+export const getAuditoriaByEntidadId = async (req: Request, res: Response): Promise<Response> => {
+    const result = await auditoria_getByEntidadId_DALC(req.params.entidad, Number(req.params.id))
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result))
+}

--- a/src/entities/Auditoria.ts
+++ b/src/entities/Auditoria.ts
@@ -1,0 +1,22 @@
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm"
+
+@Entity("auditoria")
+export class Auditoria {
+    @PrimaryGeneratedColumn()
+    Id: number
+
+    @Column()
+    Entidad: string
+
+    @Column()
+    IdRegistro: number
+
+    @Column()
+    Accion: string
+
+    @Column()
+    Usuario: string
+
+    @Column()
+    Fecha: Date
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import visionGoogle from './routes/visionGoogle.routes';
 import usuarios from './routes/usuarios.routes';
 import destinos from './routes/destinos.routes';
 import roles from './routes/roles.routes';
+import auditoriaRoutes from './routes/auditoria.routes';
 
 import tiendaNubeRoutes from "./api/tiendanube/routes/tiendanube.routes";
 import yiqiRoutes from "./api/yiqi/routes/yiqi.routes";
@@ -63,6 +64,7 @@ app.use(visionGoogle)
 app.use(usuarios)
 app.use(destinos)
 app.use(roles)
+app.use(auditoriaRoutes)
 
 
 // Rutas de Integraciones con APIS

--- a/src/routes/auditoria.routes.ts
+++ b/src/routes/auditoria.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+import { getAuditoriaByEntidad, getAuditoriaByEntidadId } from '../controllers/auditoria.controller'
+
+const router = Router()
+const prefixAPI = '/apiv3'
+
+router.get(prefixAPI + '/auditoria/:entidad/:id', getAuditoriaByEntidadId)
+router.get(prefixAPI + '/auditoria/:entidad', getAuditoriaByEntidad)
+
+export default router


### PR DESCRIPTION
## Summary
- add `Auditoria` entity for generic audit entries
- create DALC helpers for inserting/querying audit data
- hook audit logging from products, orders and guides history DALCs
- expose `/apiv3/auditoria` endpoints
- register the new router in the main application

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails to compile due to missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684a3f865120832aa90e1189ebcc02c8