### PR TITLE
Fix typed variable in producto_edit

### DIFF
--- a/src/DALC/productos.dalc.ts
+++ b/src/DALC/productos.dalc.ts
@@ -643,7 +643,7 @@ export const producto_editByBarcodeAndEmpresa_DALC = async ( barcode: string, id
 }
 
 export const producto_edit_ByProducto_DALC = async ( productoOriginal: Producto, body :any) => {
-    const datosAGuardar={}
+    const datosAGuardar: Partial<Producto> = {}
     Object.assign(datosAGuardar, body)
     datosAGuardar["FechaModificacion"] = new Date()
     await getRepository(Producto).update(productoOriginal.Id, datosAGuardar)


### PR DESCRIPTION
## Summary
- update `producto_edit_ByProducto_DALC` to use a typed variable for saved data

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684e35d30670832aa9d1d4312f2af9ca