### PR TITLE
Add error details when product stock creation fails

### DIFF
--- a/src/DALC/productos.dalc.ts
+++ b/src/DALC/productos.dalc.ts
@@ -672,8 +672,9 @@ export const producto_add_DALC = async(producto: Producto) => {
                 await productosHistorico_insert_DALC(newProducto.Id, "ALTA", newProducto.UsuarioAlta ? newProducto.UsuarioAlta : "", newProducto.FechaAlta, "")
                 return {status: true, data: result}
             } catch (error) {
-                getRepository(Producto).delete(newProducto.Id)
-                return {status: false, data: `Error creando la tabla stock del producto`}
+                await getRepository(Producto).delete(newProducto.Id)
+                console.error('Error creando la tabla stock del producto:', error.message || error.code)
+                return {status: false, data: `Error creando la tabla stock del producto: ${error.message || error.code}`}
             }
 
         } else {


### PR DESCRIPTION
## Summary
- log error details when the stock table cannot be created

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685210f91d60832aba9cb2cf49537504