### PR TITLE
Add includeEmpty filter for products list

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,15 @@ Ejemplo de respuesta:
     "Barcode": "PROD1",
     "Unidades": 10
   }
-]
+  ]
+ ```
+
+### GET /apiv3/productos/allProductosByEmpresa/:IdEmpresa
+
+Obtiene la lista de productos de una empresa. El parámetro opcional `includeEmpty` se envía por query string y determina si se devuelven productos sin stock (valor por defecto `true`).
+
+Ejemplo:
+
+```
+GET /apiv3/productos/allProductosByEmpresa/5?includeEmpty=false
 ```

--- a/src/DALC/productos.dalc.ts
+++ b/src/DALC/productos.dalc.ts
@@ -338,9 +338,9 @@ export const productos_getAll_ByEmpresa_DALC = async (idEmpresa: number) => {
     return results
 }
 
-export const productos_getAll_ByEmpresaOptimizado_DALC = async (idEmpresa: number) => {
-    const results = await createQueryBuilder("productos", "p")
-        .select("p.id as Id, p.empresa as IdEmpresa, p.barrcode as Barcode, unXcaja as UnXCaja, p.descripcion as Nombre, p.codeEmpresa as CodeEmpresa, " + 
+export const productos_getAll_ByEmpresaOptimizado_DALC = async (idEmpresa: number, includeEmpty: boolean) => {
+    const query = createQueryBuilder("productos", "p")
+        .select("p.id as Id, p.empresa as IdEmpresa, p.barrcode as Barcode, unXcaja as UnXCaja, p.descripcion as Nombre, p.codeEmpresa as CodeEmpresa, " +
           "s.unidades as Stock, p.stock_unitario as StockUnitario, p.alto as Alto, p.ancho as Ancho, p.largo as Largo, p.peso as Peso, p.precio as Precio, " +
           "(select sum(unidades) as total  from orderdetalle det " +
           "INNER JOIN ordenes ord ON det.ordenId = ord.Id " +
@@ -351,7 +351,12 @@ export const productos_getAll_ByEmpresaOptimizado_DALC = async (idEmpresa: numbe
           )
         .innerJoin("stock", "s", "p.id = s.producto")
         .where("p.empresa = :idEmpresa", {idEmpresa: idEmpresa})
-        .execute()
+
+    if (!includeEmpty) {
+        query.andWhere('s.unidades > 0')
+    }
+
+    const results = await query.execute()
      
     return results
 }

--- a/src/controllers/productos.controller.ts
+++ b/src/controllers/productos.controller.ts
@@ -368,8 +368,10 @@ export const getAllByEmpresa = async (req: Request, res: Response): Promise <Res
 }
 
 export const getAllProductosByEmpresa = async (req: Request, res: Response): Promise <Response> => {
-    const results=await productos_getAll_ByEmpresaOptimizado_DALC(parseInt(req.params.IdEmpresa))
-    
+    const includeEmptyParam = req.query.includeEmpty as string | undefined
+    const includeEmpty = includeEmptyParam === undefined ? true : includeEmptyParam === 'true' || includeEmptyParam === '1'
+    const results = await productos_getAll_ByEmpresaOptimizado_DALC(parseInt(req.params.IdEmpresa), includeEmpty)
+
     return res.json(require("lsi-util-node/API").getFormatedResponse(results))
 }
 


### PR DESCRIPTION
## Summary
- allow filtering empty-stock products
- forward includeEmpty query flag from controller
- document includeEmpty query parameter for allProductosByEmpresa endpoint

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm' and other type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68544fc515bc832a944dfdf62cf2ef83