### PR TITLE
Fix column mapping for guide state history

### DIFF
--- a/src/entities/GuiaEstadoHistorico.ts
+++ b/src/entities/GuiaEstadoHistorico.ts
@@ -5,7 +5,7 @@ export class GuiaEstadoHistorico {
     @PrimaryGeneratedColumn()
     Id: number
 
-    @Column({name: "guiaId"})
+    @Column({name: "IdGuia"})
     IdGuia: number
 
     @Column()


### PR DESCRIPTION
## Summary
- map `IdGuia` property to correct DB column in `GuiaEstadoHistorico` entity

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68578d0b2c7c832abe02ebf5348d235c