### PR TITLE
Update order handling in guia creation

### DIFF
--- a/src/DALC/guias_DALC.ts
+++ b/src/DALC/guias_DALC.ts
@@ -14,10 +14,11 @@ import { empresa_getById_DALC } from "./empresas.dalc"
 import { guiasActualizaciones_getByIdGuia_DALC } from "./guiasActualizacion_DALC"
 import { localidad_getByCodigoPostal_DALC } from "./localidades.dalc"
 import { mailSaliente_send_DALC } from "./mailSaliente.dalc"
-import { orden_getDetalleByOrden } from "./ordenes.dalc"
+import { orden_getDetalleByOrden, orden_editEstado_DALC } from "./ordenes.dalc"
 import { producto_getById_DALC } from "./productos.dalc"
 import { Usuario } from "../entities/Usuario"
 import { insertGuiaEstadoHistorico } from "./guiasEstadoHistorico.dalc"
+const { logger } = require('../helpers/logger')
 
 
 //select * from planchada where guia in (948888, 949285, 949286, 949287, 949288, 949289, 949290, 949291, 949292, 949293, 949294, 949295, 949296, 949500, 949501, 949502, 949503, 949504, 949505, 949506, 949507, 949508, 949509, 949510, 949807, 949879, 949880, 949881, 949882, 949883, 949884, 949885, 949886, 949887, 949888, 949889, 949890, 949891, 949892, 949893, 949894, 949895)
@@ -252,7 +253,9 @@ export const crearNuevaGuiaDesdeOrden_DALC = async (orden: Orden, destino: Desti
   getRepository(Guia).update(result.Id, {Comprobante: String(result.Id)})
   result.Comprobante=String(result.Id)
 
-  await getRepository(Orden).update(orden.Id, {Estado: 3, IdGuia: result.Id})
+  orden.IdGuia = result.Id
+  const ordenActualizada = await orden_editEstado_DALC(orden, 3, '')
+  logger.info(`Order ${orden.Id} moved to 3 with guide ${result.Id}`)
 
   if (nuevaGuia.EmailDestinatario && nuevaGuia.EmailDestinatario!=="") {
 


### PR DESCRIPTION
## Summary
- replace direct order update with helper function when creating guia
- log order state change with winston logger

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6857a2199dd4832aa9c6def493583d66