### PR TITLE
Add endpoint for ingresos with position info

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,28 @@ Ejemplo:
 ```
 GET /apiv3/productos/allProductosByEmpresa/5?includeEmpty=false
 ```
+
+### GET /apiv3/almacenaje/getInConPosicion/:idEmpresa/:fechaDesde/:fechaHasta
+
+Devuelve los movimientos de ingreso junto con las posiciones de cada producto/lote.
+
+Ejemplo de respuesta:
+
+```json
+[
+  {
+    "Fecha": "2023-01-01",
+    "Detalle": [
+      {
+        "idMovimiento": 1,
+        "idArticulo": "PROD1",
+        "Unidades": 10,
+        "Posiciones": [
+          { "IdPosicion": 5, "NombrePosicion": "A1", "Unidades": 8 }
+        ],
+        "SinPosicionar": 2
+      }
+    ]
+  }
+]
+```

--- a/src/routes/almacenaje.routes.ts
+++ b/src/routes/almacenaje.routes.ts
@@ -11,7 +11,8 @@ import {
     get_ingresosPorPeriodoEmpresa,
     get_movimientosPorPeriodo_totalizadosPorEmpresaPrevio,
     get_movimientosPorPeriodoAndLote,
-    get_movimientosPorPeriodoAndPartida
+    get_movimientosPorPeriodoAndPartida,
+    get_IngresosConPosicionByEmpresa
 } from "../controllers/almacenaje.controllers";
 
 const router = Router()
@@ -29,6 +30,7 @@ router.get(`${prefixAPI}/almacenaje/getMovimientosByEmpresaAndOrden/:idEmpresa/:
 router.get(`${prefixAPI}/almacenaje/getIn/:idEmpresa/:fechaDesde/:fechaHasta`, get_IngresosAlmacenajeByIdEmpresa)
 router.get(`${prefixAPI}/almacenaje/getInPorPeriodo/:fechaDesde/:fechaHasta`, get_ingresosPorPeriodo)
 router.get(`${prefixAPI}/almacenaje/getInPorPeriodoEmpresa/:fechaDesde/:fechaHasta/:idEmpresa`, get_ingresosPorPeriodoEmpresa)
+router.get(`${prefixAPI}/almacenaje/getInConPosicion/:idEmpresa/:fechaDesde/:fechaHasta`, get_IngresosConPosicionByEmpresa)
 
 router.get(`${prefixAPI}/almacenaje/getOut/:idEmpresa/:fechaDesde/:fechaHasta`, get_EgresosAlmacenajeByIdEmpresa)
 //TODO: Reparar Fechas


### PR DESCRIPTION
## Summary
- expose new route `getInConPosicion`
- implement controller `get_IngresosConPosicionByEmpresa`
- query movimientos and positions in DALC
- document endpoint in README

## Testing
- `npm run build` *(fails: Cannot find module 'express' or corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6858b8912e48832ab757702faa9df7be