### PR TITLE
Add remitos creation endpoint

### DIFF
--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from "express";
+import { getRepository } from "typeorm";
+import { orden_getById_DALC } from "../DALC/ordenes.dalc";
+import { PuntoVenta } from "../entities/PuntoVenta";
+import { Remito } from "../entities/Remito";
+import { RemitoItem } from "../entities/RemitoItem";
+
+export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promise<Response> => {
+    const idOrden = Number(req.params.idOrden);
+    const orden = await orden_getById_DALC(idOrden);
+    if (!orden) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente"));
+    }
+
+    const empresa = orden.Empresa;
+    if (!empresa) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Empresa inexistente"));
+    }
+
+    const pvRepo = getRepository(PuntoVenta);
+    let puntoVenta = await pvRepo.findOne({ where: { IdEmpresa: empresa.Id, EsInterno: true } });
+    let numero: string;
+    if (puntoVenta) {
+        const sec = puntoVenta.LastSequence + 1;
+        numero = `${puntoVenta.Prefijo}${sec}`;
+        await pvRepo.createQueryBuilder()
+            .update(PuntoVenta)
+            .set({ LastSequence: () => "last_sequence + 1" })
+            .where("id = :id", { id: puntoVenta.Id })
+            .execute();
+    } else {
+        puntoVenta = await pvRepo.findOne({ where: { IdEmpresa: empresa.Id, EsInterno: false } });
+        if (!puntoVenta) {
+            return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "Punto de venta inexistente"));
+        }
+        numero = `${puntoVenta.Prefijo}${Date.now()}`;
+    }
+
+    const remitoRepo = getRepository(Remito);
+    const nuevoRemito = remitoRepo.create({
+        IdEmpresa: empresa.Id,
+        IdPuntoVenta: puntoVenta.Id,
+        Numero: numero,
+        Fecha: new Date()
+    });
+    const remitoGuardado = await remitoRepo.save(nuevoRemito);
+
+    const itemRepo = getRepository(RemitoItem);
+    const item = itemRepo.create({ IdRemito: remitoGuardado.Id, IdOrden: orden.Id });
+    await itemRepo.save(item);
+
+    return res.json(require("lsi-util-node/API").getFormatedResponse(remitoGuardado));
+};

--- a/src/entities/PuntoVenta.ts
+++ b/src/entities/PuntoVenta.ts
@@ -1,0 +1,19 @@
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity("puntos_venta")
+export class PuntoVenta {
+    @PrimaryGeneratedColumn()
+    Id: number;
+
+    @Column({ name: "id_empresa" })
+    IdEmpresa: number;
+
+    @Column({ name: "es_interno" })
+    EsInterno: boolean;
+
+    @Column()
+    Prefijo: string;
+
+    @Column({ name: "last_sequence" })
+    LastSequence: number;
+}

--- a/src/entities/Remito.ts
+++ b/src/entities/Remito.ts
@@ -1,0 +1,29 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { Empresa } from "./Empresa";
+import { PuntoVenta } from "./PuntoVenta";
+
+@Entity("remitos")
+export class Remito {
+    @PrimaryGeneratedColumn()
+    Id: number;
+
+    @Column({ name: "id_empresa" })
+    IdEmpresa: number;
+
+    @ManyToOne(() => Empresa)
+    @JoinColumn({ name: "id_empresa" })
+    Empresa: Empresa;
+
+    @Column({ name: "id_punto_venta" })
+    IdPuntoVenta: number;
+
+    @ManyToOne(() => PuntoVenta)
+    @JoinColumn({ name: "id_punto_venta" })
+    PuntoVenta: PuntoVenta;
+
+    @Column()
+    Numero: string;
+
+    @Column()
+    Fecha: Date;
+}

--- a/src/entities/RemitoItem.ts
+++ b/src/entities/RemitoItem.ts
@@ -1,0 +1,23 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { Remito } from "./Remito";
+import { Orden } from "./Orden";
+
+@Entity("remito_items")
+export class RemitoItem {
+    @PrimaryGeneratedColumn()
+    Id: number;
+
+    @Column({ name: "id_remito" })
+    IdRemito: number;
+
+    @ManyToOne(() => Remito)
+    @JoinColumn({ name: "id_remito" })
+    Remito: Remito;
+
+    @Column({ name: "id_orden" })
+    IdOrden: number;
+
+    @ManyToOne(() => Orden)
+    @JoinColumn({ name: "id_orden" })
+    Orden: Orden;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import chofereRoutes from './routes/choferes.routes'
 import almacenajeRoutes from './routes/almacenaje.routes';
 import localidadesRoutes from './routes/localidades.routes';
 import facturacionRoutes from './routes/facturas.routes';
+import remitosRoutes from './routes/remitos.routes';
 import MovimientosStock  from './routes/movimientosStock.routes';
 import visionGoogle from './routes/visionGoogle.routes';
 import usuarios from './routes/usuarios.routes';
@@ -59,6 +60,7 @@ app.use(chofereRoutes)
 app.use(almacenajeRoutes)
 app.use(localidadesRoutes)
 app.use(facturacionRoutes)
+app.use(remitosRoutes)
 app.use(MovimientosStock)
 app.use(visionGoogle)
 app.use(usuarios)

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { crearRemitoDesdeOrden } from '../controllers/remitos.controller';
+
+const router = Router();
+const prefixAPI = '/apiv3';
+
+router.post(`${prefixAPI}/remitos/fromOrden/:idOrden`, crearRemitoDesdeOrden);
+
+export default router;


### PR DESCRIPTION
## Summary
- add PuntoVenta, Remito and RemitoItem entities
- implement `crearRemitoDesdeOrden` controller
- register new route `/apiv3/remitos/fromOrden/:idOrden`
- wire remitos routes in application

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685c0b268af0832aa0da58b7bcc30201