### PR TITLE
Add endpoint to fetch remito with items

### DIFF
--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -1,0 +1,13 @@
+import { getRepository } from "typeorm";
+import { Remito } from "../entities/Remito";
+import { RemitoItem } from "../entities/RemitoItem";
+
+export const remito_getById_DALC = async (id: number) => {
+    const result = await getRepository(Remito).findOne(id, { relations: ["Empresa", "PuntoVenta"] });
+    return result;
+};
+
+export const remito_items_getByRemito_DALC = async (idRemito: number) => {
+    const result = await getRepository(RemitoItem).find({ where: { IdRemito: idRemito }, relations: ["Orden"] });
+    return result;
+};

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { getRepository } from "typeorm";
 import { orden_getById_DALC } from "../DALC/ordenes.dalc";
+import { remito_getById_DALC, remito_items_getByRemito_DALC } from "../DALC/remitos.dalc";
 import { PuntoVenta } from "../entities/PuntoVenta";
 import { Remito } from "../entities/Remito";
 import { RemitoItem } from "../entities/RemitoItem";
@@ -50,4 +51,14 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
     await itemRepo.save(item);
 
     return res.json(require("lsi-util-node/API").getFormatedResponse(remitoGuardado));
+};
+
+export const getRemitoById = async (req: Request, res: Response): Promise<Response> => {
+    const idRemito = Number(req.params.id);
+    const remito = await remito_getById_DALC(idRemito);
+    if (!remito) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Remito inexistente"));
+    }
+    const items = await remito_items_getByRemito_DALC(remito.Id);
+    return res.json(require("lsi-util-node/API").getFormatedResponse({ ...remito, Items: items }));
 };

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { crearRemitoDesdeOrden } from '../controllers/remitos.controller';
+import { crearRemitoDesdeOrden, getRemitoById } from '../controllers/remitos.controller';
 
 const router = Router();
 const prefixAPI = '/apiv3';
 
 router.post(`${prefixAPI}/remitos/fromOrden/:idOrden`, crearRemitoDesdeOrden);
+router.get(`${prefixAPI}/remitos/:id`, getRemitoById);
 
 export default router;


### PR DESCRIPTION
## Summary
- implement DALC functions to get a remito and its items
- expose new controller method `getRemitoById`
- wire up GET `/apiv3/remitos/:id` route

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c0c971078832a956d00bdd521c2e3