### PR TITLE
Add remito query by order

### DIFF
--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -11,3 +11,11 @@ export const remito_items_getByRemito_DALC = async (idRemito: number) => {
     const result = await getRepository(RemitoItem).find({ where: { IdRemito: idRemito }, relations: ["Orden"] });
     return result;
 };
+
+export const remito_getByOrden_DALC = async (idOrden: number) => {
+    const item = await getRepository(RemitoItem).findOne({
+        where: { IdOrden: idOrden },
+        relations: ["Remito", "Remito.Empresa", "Remito.PuntoVenta"],
+    });
+    return item ? item.Remito : null;
+};

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { getRepository } from "typeorm";
 import { orden_getById_DALC } from "../DALC/ordenes.dalc";
-import { remito_getById_DALC, remito_items_getByRemito_DALC } from "../DALC/remitos.dalc";
+import { remito_getById_DALC, remito_items_getByRemito_DALC, remito_getByOrden_DALC } from "../DALC/remitos.dalc";
 import { PuntoVenta } from "../entities/PuntoVenta";
 import { Remito } from "../entities/Remito";
 import { RemitoItem } from "../entities/RemitoItem";
@@ -56,6 +56,16 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
 export const getRemitoById = async (req: Request, res: Response): Promise<Response> => {
     const idRemito = Number(req.params.id);
     const remito = await remito_getById_DALC(idRemito);
+    if (!remito) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Remito inexistente"));
+    }
+    const items = await remito_items_getByRemito_DALC(remito.Id);
+    return res.json(require("lsi-util-node/API").getFormatedResponse({ ...remito, Items: items }));
+};
+
+export const getRemitoByOrden = async (req: Request, res: Response): Promise<Response> => {
+    const idOrden = Number(req.params.idOrden);
+    const remito = await remito_getByOrden_DALC(idOrden);
     if (!remito) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Remito inexistente"));
     }

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
-import { crearRemitoDesdeOrden, getRemitoById } from '../controllers/remitos.controller';
+import { crearRemitoDesdeOrden, getRemitoById, getRemitoByOrden } from '../controllers/remitos.controller';
 
 const router = Router();
 const prefixAPI = '/apiv3';
 
 router.post(`${prefixAPI}/remitos/fromOrden/:idOrden`, crearRemitoDesdeOrden);
 router.get(`${prefixAPI}/remitos/:id`, getRemitoById);
+router.get(`${prefixAPI}/remitos/byOrden/:idOrden`, getRemitoByOrden);
 
 export default router;


### PR DESCRIPTION
## Summary
- query remitos by orden in the DALC
- expose controller method to retrieve a remito via its order
- register new endpoint for accessing a remito by order

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c0e61fcbc832ab3825e220759334f