### PR TITLE
Implement remito list by empresa

### DIFF
--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -1,4 +1,4 @@
-import { getRepository } from "typeorm";
+import { getRepository, Between } from "typeorm";
 import { Remito } from "../entities/Remito";
 import { RemitoItem } from "../entities/RemitoItem";
 
@@ -18,4 +18,21 @@ export const remito_getByOrden_DALC = async (idOrden: number) => {
         relations: ["Remito", "Remito.Empresa", "Remito.PuntoVenta"],
     });
     return item ? item.Remito : null;
+};
+
+export const remitos_getByEmpresa_DALC = async (
+    idEmpresa: number,
+    desde?: string,
+    hasta?: string
+) => {
+    const repo = getRepository(Remito);
+    const where: any = { IdEmpresa: idEmpresa };
+    if (desde && hasta) {
+        where.Fecha = Between(
+            `${desde} 00:00:00`,
+            `${hasta} 23:59:59`
+        );
+    }
+    const result = await repo.find({ where, order: { Fecha: "ASC" } });
+    return result;
 };

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
 import { getRepository } from "typeorm";
 import { orden_getById_DALC } from "../DALC/ordenes.dalc";
-import { remito_getById_DALC, remito_items_getByRemito_DALC, remito_getByOrden_DALC } from "../DALC/remitos.dalc";
+import { remito_getById_DALC, remito_items_getByRemito_DALC, remito_getByOrden_DALC, remitos_getByEmpresa_DALC } from "../DALC/remitos.dalc";
+import { empresa_getById_DALC } from "../DALC/empresas.dalc";
 import { PuntoVenta } from "../entities/PuntoVenta";
 import { Remito } from "../entities/Remito";
 import { RemitoItem } from "../entities/RemitoItem";
@@ -71,4 +72,16 @@ export const getRemitoByOrden = async (req: Request, res: Response): Promise<Res
     }
     const items = await remito_items_getByRemito_DALC(remito.Id);
     return res.json(require("lsi-util-node/API").getFormatedResponse({ ...remito, Items: items }));
+};
+
+export const listRemitosByEmpresa = async (req: Request, res: Response): Promise<Response> => {
+    const idEmpresa = Number(req.params.idEmpresa);
+    const empresa = await empresa_getById_DALC(idEmpresa);
+    if (!empresa) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Empresa inexistente"));
+    }
+    const desde = req.params.desde;
+    const hasta = req.params.hasta;
+    const remitos = await remitos_getByEmpresa_DALC(idEmpresa, desde, hasta);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(remitos));
 };

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { crearRemitoDesdeOrden, getRemitoById, getRemitoByOrden } from '../controllers/remitos.controller';
+import { crearRemitoDesdeOrden, getRemitoById, getRemitoByOrden, listRemitosByEmpresa } from '../controllers/remitos.controller';
 
 const router = Router();
 const prefixAPI = '/apiv3';
@@ -7,5 +7,6 @@ const prefixAPI = '/apiv3';
 router.post(`${prefixAPI}/remitos/fromOrden/:idOrden`, crearRemitoDesdeOrden);
 router.get(`${prefixAPI}/remitos/:id`, getRemitoById);
 router.get(`${prefixAPI}/remitos/byOrden/:idOrden`, getRemitoByOrden);
+router.get(`${prefixAPI}/remitos/byEmpresa/:idEmpresa/:desde?/:hasta?`, listRemitosByEmpresa);
 
 export default router;


### PR DESCRIPTION
## Summary
- support fetching remitos by empresa and optional period
- expose `listRemitosByEmpresa` controller and route

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c0f743814832aa468417c4576b70d