### PR TITLE
Implement remito state history logging

### DIFF
--- a/src/DALC/remitosEstadoHistorico.dalc.ts
+++ b/src/DALC/remitosEstadoHistorico.dalc.ts
@@ -1,0 +1,28 @@
+import { getRepository } from "typeorm";
+import { RemitoEstadoHistorico } from "../entities/RemitoEstadoHistorico";
+import { auditoria_insert_DALC } from "./auditoria.dalc";
+
+export const remitoEstadoHistorico_insert_DALC = async (
+    idRemito: number,
+    estado: string,
+    usuario: string,
+    fecha: Date
+) => {
+    const nuevo = new RemitoEstadoHistorico();
+    nuevo.IdRemito = idRemito;
+    nuevo.Estado = estado;
+    nuevo.Usuario = usuario;
+    nuevo.Fecha = fecha;
+    const registro = getRepository(RemitoEstadoHistorico).create(nuevo);
+    const result = await getRepository(RemitoEstadoHistorico).save(registro);
+    await auditoria_insert_DALC("Remito", idRemito, estado, usuario, fecha);
+    return result;
+};
+
+export const remitoEstadoHistorico_getByIdRemito_DALC = async (idRemito: number) => {
+    const results = await getRepository(RemitoEstadoHistorico).find({
+        where: { IdRemito: idRemito },
+        order: { Fecha: "ASC" },
+    });
+    return results;
+};

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { getRepository } from "typeorm";
 import { orden_getById_DALC } from "../DALC/ordenes.dalc";
 import { remito_getById_DALC, remito_items_getByRemito_DALC, remito_getByOrden_DALC, remitos_getByEmpresa_DALC } from "../DALC/remitos.dalc";
+import { remitoEstadoHistorico_insert_DALC, remitoEstadoHistorico_getByIdRemito_DALC } from "../DALC/remitosEstadoHistorico.dalc";
 import { empresa_getById_DALC } from "../DALC/empresas.dalc";
 import { PuntoVenta } from "../entities/PuntoVenta";
 import { Remito } from "../entities/Remito";
@@ -51,6 +52,8 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
     const item = itemRepo.create({ IdRemito: remitoGuardado.Id, IdOrden: orden.Id });
     await itemRepo.save(item);
 
+    await remitoEstadoHistorico_insert_DALC(remitoGuardado.Id, "CREADO", orden.Usuario ? orden.Usuario : "", new Date());
+
     return res.json(require("lsi-util-node/API").getFormatedResponse(remitoGuardado));
 };
 
@@ -84,4 +87,10 @@ export const listRemitosByEmpresa = async (req: Request, res: Response): Promise
     const hasta = req.params.hasta;
     const remitos = await remitos_getByEmpresa_DALC(idEmpresa, desde, hasta);
     return res.json(require("lsi-util-node/API").getFormatedResponse(remitos));
+};
+
+export const getHistoricoEstadosRemito = async (req: Request, res: Response): Promise<Response> => {
+    const idRemito = Number(req.params.idRemito);
+    const result = await remitoEstadoHistorico_getByIdRemito_DALC(idRemito);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
 };

--- a/src/entities/RemitoEstadoHistorico.ts
+++ b/src/entities/RemitoEstadoHistorico.ts
@@ -1,0 +1,19 @@
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity("remitos_estados_historico")
+export class RemitoEstadoHistorico {
+    @PrimaryGeneratedColumn()
+    Id: number;
+
+    @Column({ name: "IdRemito" })
+    IdRemito: number;
+
+    @Column()
+    Estado: string;
+
+    @Column()
+    Usuario: string;
+
+    @Column()
+    Fecha: Date;
+}

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { crearRemitoDesdeOrden, getRemitoById, getRemitoByOrden, listRemitosByEmpresa } from '../controllers/remitos.controller';
+import { crearRemitoDesdeOrden, getRemitoById, getRemitoByOrden, listRemitosByEmpresa, getHistoricoEstadosRemito } from '../controllers/remitos.controller';
 
 const router = Router();
 const prefixAPI = '/apiv3';
@@ -8,5 +8,6 @@ router.post(`${prefixAPI}/remitos/fromOrden/:idOrden`, crearRemitoDesdeOrden);
 router.get(`${prefixAPI}/remitos/:id`, getRemitoById);
 router.get(`${prefixAPI}/remitos/byOrden/:idOrden`, getRemitoByOrden);
 router.get(`${prefixAPI}/remitos/byEmpresa/:idEmpresa/:desde?/:hasta?`, listRemitosByEmpresa);
+router.get(`${prefixAPI}/remitos/historico/:idRemito`, getHistoricoEstadosRemito);
 
 export default router;


### PR DESCRIPTION
## Summary
- add RemitoEstadoHistorico entity and DALC helpers
- log initial state when remitos are created
- expose API for fetching remito history
- wire up route for retrieving the history

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c139a7f80832abf545b942cafd3cb