### PR TITLE
Update remito and venta entities

### DIFF
--- a/src/entities/Empresa.ts
+++ b/src/entities/Empresa.ts
@@ -92,4 +92,7 @@ export class Empresa {
 
     @Column({name: "salida_express"})
     SalidaExpress: boolean
+
+    @Column({name: "UsaRemitos"})
+    UsaRemitos: boolean
 }

--- a/src/entities/Orden.ts
+++ b/src/entities/Orden.ts
@@ -146,4 +146,13 @@ export class Orden {
 
     @Column({name: "usuarioPreparoOrd"})
     UsuarioPreparoOrd: string
+
+    @Column({name: "punto_venta_id"})
+    PuntoVentaId: number
+
+    @Column({name: "nro_remito"})
+    NroRemito: string
+
+    @Column({name: "despacho_plaza"})
+    DespachoPlaza: string
 }

--- a/src/entities/PuntoVenta.ts
+++ b/src/entities/PuntoVenta.ts
@@ -16,4 +16,25 @@ export class PuntoVenta {
 
     @Column({ name: "last_sequence" })
     LastSequence: number;
+
+    @Column()
+    Numero: string;
+
+    @Column({ name: "nombre_fantasia" })
+    NombreFantasia: string;
+
+    @Column()
+    Domicilio: string;
+
+    @Column()
+    Cai: string;
+
+    @Column({ name: "cai_vencimiento" })
+    CaiVencimiento: Date;
+
+    @Column()
+    Externo: boolean;
+
+    @Column()
+    Activo: boolean;
 }

--- a/src/entities/Remito.ts
+++ b/src/entities/Remito.ts
@@ -26,4 +26,22 @@ export class Remito {
 
     @Column()
     Fecha: Date;
+
+    @Column({ name: "IdOrden" })
+    IdOrden: number;
+
+    @Column({ name: "RemitoNumber" })
+    RemitoNumber: string;
+
+    @Column({ name: "Cai" })
+    Cai: string;
+
+    @Column({ name: "CaiVencimiento" })
+    CaiVencimiento: Date;
+
+    @Column({ name: "BarcodeValue" })
+    BarcodeValue: string;
+
+    @Column({ name: "TotalHojas" })
+    TotalHojas: number;
 }

--- a/src/entities/RemitoItem.ts
+++ b/src/entities/RemitoItem.ts
@@ -20,4 +20,22 @@ export class RemitoItem {
     @ManyToOne(() => Orden)
     @JoinColumn({ name: "id_orden" })
     Orden: Orden;
+
+    @Column({ name: "code_empresa" })
+    CodeEmpresa: string;
+
+    @Column()
+    Cantidad: number;
+
+    @Column()
+    Importe: number;
+
+    @Column()
+    Barcode: string;
+
+    @Column({ name: "despacho_plaza" })
+    DespachoPlaza: string;
+
+    @Column()
+    Partida: string;
 }


### PR DESCRIPTION
## Summary
- add `UsaRemitos` flag to `Empresa`
- map extra fields for `PuntoVenta`
- add remito data to `Orden`
- extend `Remito` and `RemitoItem` with new columns

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c2dcadf64832a89825e25fca4a63f