### PR TITLE
Add GET routes and docs for remitos

### DIFF
--- a/src/api/docs/documentacionApi.ts
+++ b/src/api/docs/documentacionApi.ts
@@ -118,3 +118,137 @@ router.get("/apiv3/guia/:guia/:token")
 *                 Unidades: 10
 */
 router.get("/apiv3/ordenes/byEmpresaPeriodoConDestinos/:idEmpresa/:fechaDesde/:fechaHasta")
+
+/**
+ * @openapi
+ * /apiv3/remitos/fromOrden/{idOrden}:
+ *   post:
+ *     tags:
+ *       - Remitos
+ *     summary: Crea un remito a partir de una orden
+ *     parameters:
+ *       - name: idOrden
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           example:
+ *             remito_number: "0001-00000001"
+ *             remito_items:
+ *               - IdOrden: 1
+ *                 Cantidad: 1
+ *                 Barcode: "PROD1"
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ */
+router.post("/apiv3/remitos/fromOrden/:idOrden")
+
+/**
+ * @openapi
+ * /apiv3/remitos/fromOrden/{idOrden}:
+ *   get:
+ *     tags:
+ *       - Remitos
+ *     summary: Obtiene el remito generado a partir de una orden
+ *     parameters:
+ *       - name: idOrden
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ */
+router.get("/apiv3/remitos/fromOrden/:idOrden")
+
+/**
+ * @openapi
+ * /apiv3/remitos/{id}:
+ *   get:
+ *     tags:
+ *       - Remitos
+ *     summary: Obtiene un remito por su identificador
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ */
+router.get("/apiv3/remitos/:id")
+
+/**
+ * @openapi
+ * /apiv3/remitos/byOrden/{idOrden}:
+ *   get:
+ *     tags:
+ *       - Remitos
+ *     summary: Obtiene el remito asignado a una orden
+ *     parameters:
+ *       - name: idOrden
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ */
+router.get("/apiv3/remitos/byOrden/:idOrden")
+
+/**
+ * @openapi
+ * /apiv3/remitos/byEmpresa/{idEmpresa}/{desde}/{hasta}:
+ *   get:
+ *     tags:
+ *       - Remitos
+ *     summary: Lista los remitos de una empresa en un rango de fechas
+ *     parameters:
+ *       - name: idEmpresa
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - name: desde
+ *         in: path
+ *         required: false
+ *         schema:
+ *           type: string
+ *       - name: hasta
+ *         in: path
+ *         required: false
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ */
+router.get("/apiv3/remitos/byEmpresa/:idEmpresa/:desde?/:hasta?")
+
+/**
+ * @openapi
+ * /apiv3/remitos/historico/{idRemito}:
+ *   get:
+ *     tags:
+ *       - Remitos
+ *     summary: Devuelve el histórico de estados de un remito
+ *     parameters:
+ *       - name: idRemito
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ */
+router.get("/apiv3/remitos/historico/:idRemito")

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -5,6 +5,7 @@ const router = Router();
 const prefixAPI = '/apiv3';
 
 router.post(`${prefixAPI}/remitos/fromOrden/:idOrden`, crearRemitoDesdeOrden);
+router.get(`${prefixAPI}/remitos/fromOrden/:idOrden`, getRemitoByOrden);
 router.get(`${prefixAPI}/remitos/:id`, getRemitoById);
 router.get(`${prefixAPI}/remitos/byOrden/:idOrden`, getRemitoByOrden);
 router.get(`${prefixAPI}/remitos/byEmpresa/:idEmpresa/:desde?/:hasta?`, listRemitosByEmpresa);


### PR DESCRIPTION
## Summary
- expose `GET /apiv3/remitos/fromOrden/:idOrden`
- document remito related endpoints in the OpenAPI docs

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c3513e4d0832abc6dc4179e09e619