### PR TITLE
Add Thunder Client remitos requests

### DIFF
--- a/thunder-tests/thunderCollection.db
+++ b/thunder-tests/thunderCollection.db
@@ -1,1 +1,120 @@
-{"folders":[{"containerId":"","sortNum":10000,"name":"Empresas","_id":"a7699f7f-4a44-42e7-9836-fa7823b7e81e","created":"2021-09-18T14:49:40.150Z"},{"containerId":"","sortNum":20000,"name":"Posiciones","_id":"0df7c6cf-fab9-4f81-bb5a-4232929d9ecb","created":"2021-09-18T16:46:27.031Z"},{"containerId":"","sortNum":30000,"name":"Productos","_id":"6523704f-e652-4b4f-8be3-bfc6774f6c03","created":"2021-09-18T16:56:21.130Z"},{"containerId":"","sortNum":40000,"name":"Ordenes","_id":"96511fdf-d6b7-4d88-9753-ebb49fbb1507","created":"2021-09-18T18:26:59.220Z"},{"containerId":"","sortNum":50000,"name":"Guias","_id":"9a70d4c2-3bc5-470e-babb-80e357e723c9","created":"2021-09-18T18:30:02.958Z"},{"containerId":"","sortNum":60000,"name":"Choferes","_id":"0440c3ab-c133-4be5-acb0-16de1be28c86","created":"2021-09-18T18:35:27.276Z"},{"containerId":"","sortNum":70000,"name":"Tiendanube","_id":"11f63a10-41fb-4c75-bd7b-d964c684ffd6","created":"2021-09-18T18:39:26.885Z"},{"containerId":"11f63a10-41fb-4c75-bd7b-d964c684ffd6","sortNum":80000,"name":"Productos","_id":"0a14c7f8-908f-4c99-90f7-8522a0601624","created":"2021-09-18T18:39:37.678Z"},{"containerId":"11f63a10-41fb-4c75-bd7b-d964c684ffd6","sortNum":90000,"name":"Ventas","_id":"b5b68e7b-ec79-4845-9267-f744e3340fae","created":"2021-09-18T18:41:40.048Z"},{"containerId":"","sortNum":100000,"name":"Yiqi","_id":"294cd023-6c31-405d-aedb-42dd40b8634d","created":"2021-09-18T18:43:32.623Z"},{"containerId":"294cd023-6c31-405d-aedb-42dd40b8634d","sortNum":110000,"name":"A Yiqi","_id":"9545cc4a-a0de-416c-bf4e-a7b049788614","created":"2021-09-18T18:43:53.838Z"},{"containerId":"294cd023-6c31-405d-aedb-42dd40b8634d","sortNum":120000,"name":"A API A54","_id":"469d942c-cdcc-4125-9046-59be2a49e136","created":"2021-09-18T18:49:13.757Z"},{"containerId":"","sortNum":130000,"name":"WooCommerce","_id":"b961792c-b1fa-4136-8e2e-ba40fab7c75d","created":"2021-09-18T18:55:03.554Z"},{"containerId":"b961792c-b1fa-4136-8e2e-ba40fab7c75d","sortNum":140000,"name":"A WooCommerce","_id":"4f55d982-845c-412e-b7bd-ca89a2cd4e8f","created":"2021-09-18T18:55:13.260Z"},{"containerId":"b961792c-b1fa-4136-8e2e-ba40fab7c75d","sortNum":150000,"name":"A API A54","_id":"972e59ee-7c4b-4dfd-8f7d-9f5d21dd3fbc","created":"2021-09-18T18:59:07.269Z"}],"sortNum":10000,"colName":"Area54","_id":"661a9dd7-4539-4a53-af30-97b9a211e6db","created":"2021-09-18T14:49:27.323Z"}
+{
+  "folders": [
+    {
+      "containerId": "",
+      "sortNum": 10000,
+      "name": "Empresas",
+      "_id": "a7699f7f-4a44-42e7-9836-fa7823b7e81e",
+      "created": "2021-09-18T14:49:40.150Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 20000,
+      "name": "Posiciones",
+      "_id": "0df7c6cf-fab9-4f81-bb5a-4232929d9ecb",
+      "created": "2021-09-18T16:46:27.031Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 30000,
+      "name": "Productos",
+      "_id": "6523704f-e652-4b4f-8be3-bfc6774f6c03",
+      "created": "2021-09-18T16:56:21.130Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 40000,
+      "name": "Ordenes",
+      "_id": "96511fdf-d6b7-4d88-9753-ebb49fbb1507",
+      "created": "2021-09-18T18:26:59.220Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 50000,
+      "name": "Guias",
+      "_id": "9a70d4c2-3bc5-470e-babb-80e357e723c9",
+      "created": "2021-09-18T18:30:02.958Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 60000,
+      "name": "Choferes",
+      "_id": "0440c3ab-c133-4be5-acb0-16de1be28c86",
+      "created": "2021-09-18T18:35:27.276Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 70000,
+      "name": "Tiendanube",
+      "_id": "11f63a10-41fb-4c75-bd7b-d964c684ffd6",
+      "created": "2021-09-18T18:39:26.885Z"
+    },
+    {
+      "containerId": "11f63a10-41fb-4c75-bd7b-d964c684ffd6",
+      "sortNum": 80000,
+      "name": "Productos",
+      "_id": "0a14c7f8-908f-4c99-90f7-8522a0601624",
+      "created": "2021-09-18T18:39:37.678Z"
+    },
+    {
+      "containerId": "11f63a10-41fb-4c75-bd7b-d964c684ffd6",
+      "sortNum": 90000,
+      "name": "Ventas",
+      "_id": "b5b68e7b-ec79-4845-9267-f744e3340fae",
+      "created": "2021-09-18T18:41:40.048Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 100000,
+      "name": "Yiqi",
+      "_id": "294cd023-6c31-405d-aedb-42dd40b8634d",
+      "created": "2021-09-18T18:43:32.623Z"
+    },
+    {
+      "containerId": "294cd023-6c31-405d-aedb-42dd40b8634d",
+      "sortNum": 110000,
+      "name": "A Yiqi",
+      "_id": "9545cc4a-a0de-416c-bf4e-a7b049788614",
+      "created": "2021-09-18T18:43:53.838Z"
+    },
+    {
+      "containerId": "294cd023-6c31-405d-aedb-42dd40b8634d",
+      "sortNum": 120000,
+      "name": "A API A54",
+      "_id": "469d942c-cdcc-4125-9046-59be2a49e136",
+      "created": "2021-09-18T18:49:13.757Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 130000,
+      "name": "WooCommerce",
+      "_id": "b961792c-b1fa-4136-8e2e-ba40fab7c75d",
+      "created": "2021-09-18T18:55:03.554Z"
+    },
+    {
+      "containerId": "b961792c-b1fa-4136-8e2e-ba40fab7c75d",
+      "sortNum": 140000,
+      "name": "A WooCommerce",
+      "_id": "4f55d982-845c-412e-b7bd-ca89a2cd4e8f",
+      "created": "2021-09-18T18:55:13.260Z"
+    },
+    {
+      "containerId": "b961792c-b1fa-4136-8e2e-ba40fab7c75d",
+      "sortNum": 150000,
+      "name": "A API A54",
+      "_id": "972e59ee-7c4b-4dfd-8f7d-9f5d21dd3fbc",
+      "created": "2021-09-18T18:59:07.269Z"
+    },
+    {
+      "containerId": "",
+      "sortNum": 80000,
+      "name": "Remitos",
+      "_id": "29ca8d8a-7cf8-409c-a408-9c52fcf74372",
+      "created": "2025-06-25T17:50:31.701Z"
+    }
+  ],
+  "sortNum": 10000,
+  "colName": "Area54",
+  "_id": "661a9dd7-4539-4a53-af30-97b9a211e6db",
+  "created": "2021-09-18T14:49:27.323Z"
+}

--- a/thunder-tests/thunderclient.db
+++ b/thunder-tests/thunderclient.db
@@ -52,3 +52,83 @@
 {"containerId":"a7699f7f-4a44-42e7-9836-fa7823b7e81e","sortNum":20000,"headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],"colId":"661a9dd7-4539-4a53-af30-97b9a211e6db","name":"Obtener una por Id","url":"{{URL}}/apiv3/empresa/149","method":"GET","modified":"2021-09-18T15:07:22.083Z","created":"2021-09-18T15:05:13.743Z","_id":"fce74d02-2b86-4e08-b047-bf7d78cb28df","params":[],"auth":{"type":"basic","basic":{"username":"A54APIDev","password":"A54API4470Dev!"}},"tests":[]}
 {"containerId":"9a70d4c2-3bc5-470e-babb-80e357e723c9","sortNum":60000,"headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],"colId":"661a9dd7-4539-4a53-af30-97b9a211e6db","name":"Registrar foto de documentacion","url":"{{URL}}/apiv3/guia/fotoDocumentacionEntrega/689390/aabbcc","method":"PUT","modified":"2021-09-18T18:35:02.188Z","created":"2021-09-18T18:34:39.841Z","_id":"ff5232a8-2082-475f-9cd1-4266ca8b502c","params":[],"body":{"type":"json","raw":"{\"idChofer\": 1210, \"fecha\": \"2021-01-07\", \"estado\": \"ENTREGADO\", \"nombreReceptor\": \"\"}","form":[]},"auth":{"type":"basic","basic":{"username":"A54APIDev","password":"A54API4470Dev!"}},"tests":[]}
 {"containerId":"469d942c-cdcc-4125-9046-59be2a49e136","sortNum":30000,"headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],"colId":"661a9dd7-4539-4a53-af30-97b9a211e6db","name":"Obtener ventas","url":"{{URL}}/apiv3/yiqi/ventas/obtener/163","method":"GET","modified":"2021-09-28T15:29:22.703Z","created":"2021-09-18T18:53:32.855Z","_id":"ff7ec126-e962-4aab-a662-b0537003d292","params":[],"auth":{"type":"basic","basic":{"username":"A54APIProdUniversal","password":"A54API4470ProdUniversal!"}},"tests":[]}
+{
+  "containerId":"29ca8d8a-7cf8-409c-a408-9c52fcf74372",
+  "sortNum":10000,
+  "headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],
+  "colId":"661a9dd7-4539-4a53-af30-97b9a211e6db",
+  "name":"Crear remito desde orden (interno)",
+  "url":"{{URL}}/apiv3/remitos/fromOrden/12345",
+  "method":"POST",
+  "modified":"2025-06-25T17:50:31.701Z",
+  "created":"2025-06-25T17:50:31.701Z",
+  "_id":"2c5e3f36-7aae-4a15-b956-f3eda3cd752b",
+  "params":[],
+  "body":{"type":"json","raw":"{\"remito_items\":[{\"IdOrden\":1,\"Cantidad\":1,\"Barcode\":\"PROD1\"}]}","form":[]},
+  "auth":{"type":"basic","basic":{"username":"A54APIDev","password":"A54API4470Dev!"}},
+  "tests":[]
+}
+{
+  "containerId":"29ca8d8a-7cf8-409c-a408-9c52fcf74372",
+  "sortNum":20000,
+  "headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],
+  "colId":"661a9dd7-4539-4a53-af30-97b9a211e6db",
+  "name":"Crear remito desde orden (externo)",
+  "url":"{{URL}}/apiv3/remitos/fromOrden/12345",
+  "method":"POST",
+  "modified":"2025-06-25T17:50:31.701Z",
+  "created":"2025-06-25T17:50:31.701Z",
+  "_id":"d6d333db-d7ef-4183-9dd2-87582602f7b9",
+  "params":[],
+  "body":{"type":"json","raw":"{\"remito_number\":\"0001-00000001\",\"remito_items\":[{\"IdOrden\":1,\"Cantidad\":1,\"Barcode\":\"PROD1\"}]}","form":[]},
+  "auth":{"type":"basic","basic":{"username":"A54APIDev","password":"A54API4470Dev!"}},
+  "tests":[]
+}
+{
+  "containerId":"29ca8d8a-7cf8-409c-a408-9c52fcf74372",
+  "sortNum":30000,
+  "headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],
+  "colId":"661a9dd7-4539-4a53-af30-97b9a211e6db",
+  "name":"Obtener remito por id",
+  "url":"{{URL}}/apiv3/remitos/1",
+  "method":"GET",
+  "modified":"2025-06-25T17:50:31.701Z",
+  "created":"2025-06-25T17:50:31.701Z",
+  "_id":"5ccebb72-69ad-4962-ba6f-9fa725c5f958",
+  "params":[],
+  "auth":{"type":"basic","basic":{"username":"A54APIDev","password":"A54API4470Dev!"}},
+  "tests":[],
+  "body":{"type":"json","raw":"{\"Id\":1,\"Numero\":\"0001-00000001\",\"Items\":[{\"IdOrden\":1,\"Cantidad\":1,\"Barcode\":\"PROD1\"}]}","form":[]}
+}
+{
+  "containerId":"29ca8d8a-7cf8-409c-a408-9c52fcf74372",
+  "sortNum":40000,
+  "headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],
+  "colId":"661a9dd7-4539-4a53-af30-97b9a211e6db",
+  "name":"Obtener remito por orden",
+  "url":"{{URL}}/apiv3/remitos/byOrden/1",
+  "method":"GET",
+  "modified":"2025-06-25T17:50:31.701Z",
+  "created":"2025-06-25T17:50:31.701Z",
+  "_id":"82ffcae8-224b-4d48-96c3-c7cf61a22aed",
+  "params":[],
+  "auth":{"type":"basic","basic":{"username":"A54APIDev","password":"A54API4470Dev!"}},
+  "tests":[],
+  "body":{"type":"json","raw":"{\"Id\":1,\"Numero\":\"0001-00000001\",\"Items\":[{\"IdOrden\":1,\"Cantidad\":1,\"Barcode\":\"PROD1\"}]}","form":[]}
+}
+{
+  "containerId":"29ca8d8a-7cf8-409c-a408-9c52fcf74372",
+  "sortNum":50000,
+  "headers":[{"name":"Accept","value":"*/*"},{"name":"User-Agent","value":"Thunder Client (https://www.thunderclient.io)"}],
+  "colId":"661a9dd7-4539-4a53-af30-97b9a211e6db",
+  "name":"Listar remitos por empresa",
+  "url":"{{URL}}/apiv3/remitos/byEmpresa/33",
+  "method":"GET",
+  "modified":"2025-06-25T17:50:31.701Z",
+  "created":"2025-06-25T17:50:31.701Z",
+  "_id":"435b9b3a-8162-4118-a30b-faa0af85fe06",
+  "params":[],
+  "auth":{"type":"basic","basic":{"username":"A54APIDev","password":"A54API4470Dev!"}},
+  "tests":[],
+  "body":{"type":"json","raw":"[{\"Id\":1,\"Numero\":\"0001-00000001\"}]","form":[]}
+}


### PR DESCRIPTION
## Summary
- add folder *Remitos* to Thunder Client collection
- add new requests for remito creation and queries with sample bodies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c3629d1f4832aa081d4955f8c5a6b