### PR TITLE
Add Orden audit migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,12 @@ Ejemplo de respuesta:
   }
 ]
 ```
+
+## Migraciones
+
+Despues de compilar el proyecto con `npm run build` es posible ejecutar las migraciones de base de datos con el comando:
+
+```
+typeorm migration:run
+```
+

--- a/src/database.ts
+++ b/src/database.ts
@@ -8,6 +8,7 @@ export const conectaProduccion = async () => {
         "password": "APIv3Prod1512@!@",
         "database": "godoy",
         "entities": ["dist/entities/**/*.js", "dist/entities/tiendanube/**/*.js"],
+        "migrations": ["dist/migrations/**/*.js"],
         "synchronize": false,
         "logging": true,
         "logger": "file"
@@ -23,6 +24,7 @@ export const conectaProduccionUniversal = async () => {
         "password": "APIv3ProdUniversal1512@!@",
         "database": "godoy",
         "entities": ["dist/entities/**/*.js", "dist/entities/tiendanube/**/*.js"],
+        "migrations": ["dist/migrations/**/*.js"],
         "synchronize": false,
         "logging": true,
         "logger": "file"
@@ -38,6 +40,7 @@ export const conectaDesarrollo = async () => {
         "password": "APIv3Dev!",
         "database": "hermes_testing",
         "entities": ["dist/entities/**/*.js", "dist/entities/tiendanube/**/*.js"],
+        "migrations": ["dist/migrations/**/*.js"],
         "synchronize": false,
         "logging": true,
         "logger": "file"

--- a/src/migrations/168-add-audit-fields-orden.ts
+++ b/src/migrations/168-add-audit-fields-orden.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddAuditFieldsOrden168 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            "ordenes",
+            new TableColumn({
+                name: "usuario_creacion",
+                type: "varchar",
+                length: "100",
+                isNullable: true,
+            })
+        );
+        await queryRunner.addColumn(
+            "ordenes",
+            new TableColumn({
+                name: "usuario_modificacion",
+                type: "varchar",
+                length: "100",
+                isNullable: true,
+            })
+        );
+        await queryRunner.addColumn(
+            "ordenes",
+            new TableColumn({
+                name: "fecha_modificacion",
+                type: "timestamp",
+                isNullable: true,
+            })
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("ordenes", "fecha_modificacion");
+        await queryRunner.dropColumn("ordenes", "usuario_modificacion");
+        await queryRunner.dropColumn("ordenes", "usuario_creacion");
+    }
+}


### PR DESCRIPTION
## Summary
- add audit columns for Orden via TypeORM migration
- configure connection to load compiled migrations
- document how to run migrations after building

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685d776d2224832abbe828caf38a9217