### PR TITLE
Fix Orden column name

### DIFF
--- a/src/entities/Orden.ts
+++ b/src/entities/Orden.ts
@@ -102,7 +102,7 @@ export class Orden {
     @Column()
     Fecha: string
 
-    @CreateDateColumn({name: "fecha_creacion", type: "timestamp"})
+    @CreateDateColumn({name: "fechaCreacion", type: "timestamp"})
     FechaCreacion: Date
 
     @Column({name: "fechaPreparado"})


### PR DESCRIPTION
## Summary
- fix column name for Orden fechaCreacion

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685e29209314832aab1ad169f8784f6f