### PR TITLE
Fix PART product lookup when creating orders

### DIFF
--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -195,6 +195,15 @@ export const orden_generarNueva = async (
     } else if(tienePART){
         //Me fijo si todos los artículos del detalle existen para la empresa
         for (const unDetalle of detalle) {
+            if (!unDetalle.idProducto) {
+                const producto = await producto_getByBarcodeAndEmpresa_DALC(unDetalle.barcode, empresa.Id)
+                if (!producto) {
+                    errores.push("Barcode producto " + unDetalle.barcode + " inexistente")
+                    continue
+                }
+                unDetalle.idProducto = producto.Id
+            }
+
             const productos = await getProductoByPartidaAndEmpresaAndProductoV2_DALC(
                 empresa.Id,
                 unDetalle.partida,
@@ -205,6 +214,7 @@ export const orden_generarNueva = async (
             } else {
                 const unProducto = productos[0]
                 unDetalle.producto = unProducto
+                unDetalle.idPartida = unProducto.Id
                 if (unDetalle.cantidad > (unProducto.Stock - unProducto.StockComprometido)) {
                     errores.push("Partida " + unProducto.Partida + " - Barcode: " + unProducto.Barcode + " - Nombre: " + unProducto.Nombre + " - Stock: " + unProducto.Stock + " - Comprometido: " + unProducto.StockComprometido + " - Solicitado: " + unDetalle.cantidad + " - Estado: Insuficiente")
                 } else {


### PR DESCRIPTION
## Summary
- when creating an order for enterprises that work with PART, resolve the product from barcode if not provided
- save the fetched Partida Id on the detail for later persistence

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6862a3372aa4832a9a710cc88c593de8