### PR TITLE
Add logging and fix remito mapping

### DIFF
--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -393,7 +393,9 @@ export const orden_generarNueva = async (
         }
         
         const resultToSave=getRepository(Orden).create(nuevaOrden)
+        console.log('[ORDEN DALC] Creando orden para empresa', empresa.Id)
         const nuevaOrdenCreada=await getRepository(Orden).save(resultToSave)
+        console.log('[ORDEN DALC] Orden creada', nuevaOrdenCreada.Id)
         if (nuevaOrdenCreada) {
             await ordenEstadoHistorico_insert_DALC(nuevaOrdenCreada.Id, nuevaOrdenCreada.Estado, usuario, new Date())
         }
@@ -418,6 +420,7 @@ export const orden_generarNueva = async (
 
             const resultToSave=getRepository(OrdenDetalle).create(unaOrdenDetalle)
             const nuevoDetalleCreado=await getRepository(OrdenDetalle).save(resultToSave)
+            console.log('[ORDEN DALC] Detalle creado', nuevoDetalleCreado.Id)
         
             for (const unaPosicionUsada of unItem.posicionesUsadas) {
                 const unaPosicionEnOrdenDetalle=new PosicionEnOrdenDetalle()
@@ -433,6 +436,7 @@ export const orden_generarNueva = async (
 
                 const resultToSave=getRepository(PosicionEnOrdenDetalle).create(unaPosicionEnOrdenDetalle)
                 const nuevaPosicionEnDetalle=await getRepository(PosicionEnOrdenDetalle).save(resultToSave)
+                console.log('[ORDEN DALC] Posicion en detalle creada', nuevaPosicionEnDetalle.Id)
            
             }
         

--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -43,11 +43,13 @@ export const remito_crear_DALC = async (
 ) => {
     const repoRemito = getRepository(Remito);
     const nuevoRemito = repoRemito.create(remito);
+    console.log('[REMITO DALC] Guardando remito', nuevoRemito);
     const guardado = await repoRemito.save(nuevoRemito);
     if (items.length > 0) {
         const repoItem = getRepository(RemitoItem);
         const itemsAguardar = items.map((it) => ({ ...it, IdRemito: guardado.Id }));
         const regs = repoItem.create(itemsAguardar as any);
+        console.log('[REMITO DALC] Guardando items de remito:', itemsAguardar.length);
         await repoItem.save(regs);
     }
     return guardado;

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -46,8 +46,10 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
     }
 
     if (!empresa.UsaRemitos) {
+        console.log('[REMITO] Empresa', empresa.Id, 'no usa remitos');
         return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "Empresa no utiliza remitos"));
     }
+    console.log('[REMITO] Empresa', empresa.Id, 'usa remitos');
 
     const pvRepo = getRepository(PuntoVenta);
     let puntoVenta = await pvRepo.findOne({ where: { IdEmpresa: empresa.Id, EsInterno: true, Activo: true } });
@@ -56,6 +58,7 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
         const sec = puntoVenta.LastSequence + 1;
         const secStr = String(sec).padStart(8, '0');
         numero = `${puntoVenta.Numero}-${secStr}`;
+        console.log('[REMITO] Numero generado', numero, 'para punto de venta', puntoVenta.Id);
         await pvRepo.createQueryBuilder()
             .update(PuntoVenta)
             .set({ LastSequence: () => "last_sequence + 1" })
@@ -63,6 +66,7 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
             .execute();
     } else {
         numero = req.body.remito_number || orden.NroRemito;
+        console.log('[REMITO] Numero recibido', numero);
         if (!numero) {
             return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "remito_number requerido"));
         }
@@ -84,6 +88,7 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
         TotalHojas: totalHojas,
     };
     const remitoGuardado = await remito_crear_DALC(nuevoRemito, items);
+    console.log('[REMITO] Remito guardado', remitoGuardado.Id);
 
     await remitoEstadoHistorico_insert_DALC(remitoGuardado.Id, "CREADO", orden.Usuario ? orden.Usuario : "", new Date());
 

--- a/src/entities/RemitoItem.ts
+++ b/src/entities/RemitoItem.ts
@@ -7,11 +7,11 @@ export class RemitoItem {
     @PrimaryGeneratedColumn()
     Id: number;
 
-    @Column({ name: "id_remito" })
+    @Column({ name: "remito_id" })
     IdRemito: number;
 
     @ManyToOne(() => Remito)
-    @JoinColumn({ name: "id_remito" })
+    @JoinColumn({ name: "remito_id" })
     Remito: Remito;
 
     @Column({ name: "id_orden" })


### PR DESCRIPTION
## Summary
- add console logs to remito creation flow
- add console logs for order creation steps
- log DALC inserts for remitos
- map `remito_id` column in `RemitoItem` entity

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6862ba2b3300832a84dbffa69e3dc812