### PR TITLE
Load Remito items via relation

### DIFF
--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -3,7 +3,7 @@ import { Remito } from "../entities/Remito";
 import { RemitoItem } from "../entities/RemitoItem";
 
 export const remito_getById_DALC = async (id: number) => {
-    const result = await getRepository(Remito).findOne(id, { relations: ["Empresa", "PuntoVenta"] });
+    const result = await getRepository(Remito).findOne(id, { relations: ["Empresa", "PuntoVenta", "Items", "Items.Orden"] });
     return result;
 };
 
@@ -15,7 +15,7 @@ export const remito_items_getByRemito_DALC = async (idRemito: number) => {
 export const remito_getByOrden_DALC = async (idOrden: number) => {
     const item = await getRepository(RemitoItem).findOne({
         where: { IdOrden: idOrden },
-        relations: ["Remito", "Remito.Empresa", "Remito.PuntoVenta"],
+        relations: ["Remito", "Remito.Empresa", "Remito.PuntoVenta", "Remito.Items", "Remito.Items.Orden"],
     });
     return item ? item.Remito : null;
 };

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -2,10 +2,9 @@ import { Request, Response } from "express";
 import { getRepository } from "typeorm";
 import { orden_getById_DALC, orden_actualizarEstado_DALC } from "../DALC/ordenes.dalc";
 import { 
-    remito_getById_DALC, 
-    remito_items_getByRemito_DALC, 
-    remito_getByOrden_DALC, 
-    remitos_getByEmpresa_DALC, 
+    remito_getById_DALC,
+    remito_getByOrden_DALC,
+    remitos_getByEmpresa_DALC,
     remito_crear_DALC, 
     remito_actualizarEstado_DALC 
 } from "../DALC/remitos.dalc";
@@ -101,8 +100,7 @@ export const getRemitoById = async (req: Request, res: Response): Promise<Respon
     if (!remito) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Remito inexistente"));
     }
-    const items = await remito_items_getByRemito_DALC(remito.Id);
-    return res.json(require("lsi-util-node/API").getFormatedResponse({ ...remito, Items: items }));
+    return res.json(require("lsi-util-node/API").getFormatedResponse(remito));
 };
 
 export const getRemitoByOrden = async (req: Request, res: Response): Promise<Response> => {
@@ -111,8 +109,7 @@ export const getRemitoByOrden = async (req: Request, res: Response): Promise<Res
     if (!remito) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Remito inexistente"));
     }
-    const items = await remito_items_getByRemito_DALC(remito.Id);
-    return res.json(require("lsi-util-node/API").getFormatedResponse({ ...remito, Items: items }));
+    return res.json(require("lsi-util-node/API").getFormatedResponse(remito));
 };
 
 export const listRemitosByEmpresa = async (req: Request, res: Response): Promise<Response> => {

--- a/src/entities/Remito.ts
+++ b/src/entities/Remito.ts
@@ -1,7 +1,8 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, CreateDateColumn, UpdateDateColumn } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToMany, CreateDateColumn, UpdateDateColumn } from "typeorm";
 import { Empresa } from "./Empresa";
 import { PuntoVenta } from "./PuntoVenta";
 import { Orden } from "./Orden";
+import { RemitoItem } from "./RemitoItem";
 
 @Entity("remitos")
 export class Remito {
@@ -34,6 +35,9 @@ export class Remito {
     @ManyToOne(() => Orden, { eager: true })
     @JoinColumn({ name: "orden_id" })
     Orden: Orden;
+
+    @OneToMany(() => RemitoItem, item => item.Remito)
+    Items: RemitoItem[];
 
     @Column({ name: "remito_number" })
     RemitoNumber: string;


### PR DESCRIPTION
## Summary
- relate Remito with RemitoItem via `Items`
- include items when retrieving a remito from DALC
- simplify controllers to rely on the entity relation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862f2f71fe8832a995f549286ea2e14