### PR TITLE
Add remito creation logging

### DIFF
--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -45,12 +45,15 @@ export const remito_crear_DALC = async (
     const nuevoRemito = repoRemito.create(remito);
     console.log('[REMITO DALC] Guardando remito', nuevoRemito);
     const guardado = await repoRemito.save(nuevoRemito);
+    console.log('[REMITO DALC] Remito generado con id', guardado.Id);
     if (items.length > 0) {
         const repoItem = getRepository(RemitoItem);
         const itemsAguardar = items.map((it) => ({ ...it, IdRemito: guardado.Id }));
         const regs = repoItem.create(itemsAguardar as any);
-        console.log('[REMITO DALC] Guardando items de remito:', itemsAguardar.length);
         await repoItem.save(regs);
+        console.log('[REMITO DALC] Items guardados:', itemsAguardar.length);
+    } else {
+        console.log('[REMITO DALC] Remito sin items a guardar');
     }
     return guardado;
 };

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -86,8 +86,16 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
         RemitoNumber: numero!,
         TotalHojas: totalHojas,
     };
+    console.log(
+        '[REMITO] Creando remito para orden',
+        orden.Id,
+        'numero',
+        numero,
+        'items',
+        items.length
+    );
     const remitoGuardado = await remito_crear_DALC(nuevoRemito, items);
-    console.log('[REMITO] Remito guardado', remitoGuardado.Id);
+    console.log('[REMITO] Remito creado correctamente', remitoGuardado.Id);
 
     await remitoEstadoHistorico_insert_DALC(remitoGuardado.Id, "CREADO", orden.Usuario ? orden.Usuario : "", new Date());
 


### PR DESCRIPTION
## Summary
- log order id, generated number and item count before creating remito
- confirm creation success afterward
- log remito id and items saved inside DALC

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6862f5fb1b9c832ab23175f931b77434