### PR TITLE
Refactor remito lookup by order

### DIFF
--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -13,11 +13,10 @@ export const remito_items_getByRemito_DALC = async (idRemito: number) => {
 };
 
 export const remito_getByOrden_DALC = async (idOrden: number) => {
-    const item = await getRepository(RemitoItem).findOne({
+    return await getRepository(Remito).findOne({
         where: { IdOrden: idOrden },
-        relations: ["Remito", "Remito.Empresa", "Remito.PuntoVenta", "Remito.Items", "Remito.Items.Orden"],
+        relations: ["Empresa", "PuntoVenta"],
     });
-    return item ? item.Remito : null;
 };
 
 export const remitos_getByEmpresa_DALC = async (


### PR DESCRIPTION
## Summary
- query Remito table directly when searching by order

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6862f75654e4832aa7242c086f09caba