### PR TITLE
Allow orders without remito when automatic numbering exists

### DIFF
--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -388,8 +388,8 @@ export const orden_generarNueva = async (
         if (puntoVentaId !== undefined) {
             nuevaOrden.PuntoVentaId = puntoVentaId;
         }
-        if (nroRemito !== undefined) {
-            nuevaOrden.NroRemito = nroRemito;
+        if (nroRemito && nroRemito.trim() !== "") {
+            nuevaOrden.NroRemito = nroRemito.trim();
         }
         
         const resultToSave=getRepository(Orden).create(nuevaOrden)


### PR DESCRIPTION
## Summary
- look up internal punto de venta when creating orders
- don't require `nroRemito` when company can auto generate numbers
- sanitize `nroRemito` value
- avoid inserting blank `nroRemito`

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6863045b8884832a8a25e4538e612ae1