### PR TITLE
Fix internal punto de venta lookup

### DIFF
--- a/src/DALC/puntosVenta.dalc.ts
+++ b/src/DALC/puntosVenta.dalc.ts
@@ -6,7 +6,7 @@ export const puntoVenta_getByEmpresa_DALC = async (idEmpresa: number) => {
 };
 
 export const puntoVenta_getInternoByEmpresa_DALC = async (idEmpresa: number) => {
-    return await getRepository(PuntoVenta).findOne({ where: { IdEmpresa: idEmpresa, EsInterno: true } });
+    return await getRepository(PuntoVenta).findOne({ where: { IdEmpresa: idEmpresa, Externo: false } });
 };
 
 export const puntoVenta_crearExterno_DALC = async (body: Partial<PuntoVenta>) => {

--- a/src/entities/PuntoVenta.ts
+++ b/src/entities/PuntoVenta.ts
@@ -8,8 +8,17 @@ export class PuntoVenta {
     @Column({ name: "empresa_id" })
     IdEmpresa: number;
 
-    @Column({ name: "es_interno" })
+    @Column({
+        name: "externo",
+        transformer: {
+            from: (value: boolean) => !value,
+            to: (value: boolean) => !value,
+        },
+    })
     EsInterno: boolean;
+
+    @Column({ name: "externo" })
+    Externo: boolean;
 
     @Column()
     Prefijo: string;
@@ -31,9 +40,6 @@ export class PuntoVenta {
 
     @Column({ name: "cai_vencimiento" })
     CaiVencimiento: Date;
-
-    @Column()
-    Externo: boolean;
 
     @Column()
     Activo: boolean;


### PR DESCRIPTION
## Summary
- map `EsInterno` to the real `externo` column using a transformer
- query internal puntos de venta using `Externo: false`

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68630e4c8c40832aa785c8ec9b371ae8