### PR TITLE
Fix remitos Numero column

### DIFF
--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -80,7 +80,6 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
     const nuevoRemito: Partial<Remito> = {
         IdEmpresa: empresa.Id,
         IdPuntoVenta: puntoVenta ? puntoVenta.Id : undefined,
-        Numero: numero!,
         Fecha: new Date(),
         IdOrden: orden.Id,
         RemitoNumber: numero!,

--- a/src/entities/Remito.ts
+++ b/src/entities/Remito.ts
@@ -24,9 +24,6 @@ export class Remito {
     PuntoVenta: PuntoVenta;
 
     @Column()
-    Numero: string;
-
-    @Column()
     Fecha: Date;
 
     @Column({ name: "orden_id" })


### PR DESCRIPTION
## Summary
- remove `Numero` column from `Remito` entity
- stop sending `Numero` when creating a remito

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68631d151f04832a94b36c6edfb55125