### PR TITLE
Remove unused Prefijo column mapping

### DIFF
--- a/src/entities/PuntoVenta.ts
+++ b/src/entities/PuntoVenta.ts
@@ -20,8 +20,6 @@ export class PuntoVenta {
     @Column({ name: "externo" })
     Externo: boolean;
 
-    @Column()
-    Prefijo: string;
 
     @Column({ name: "last_sequence" })
     LastSequence: number;


### PR DESCRIPTION
## Summary
- clean up `PuntoVenta` entity by removing the unused `Prefijo` field

## Testing
- `npm run build` *(fails: Cannot find module packages)*

------
https://chatgpt.com/codex/tasks/task_e_68632007f49c832aa35d995fcff195d1