### PR TITLE
Update remito creation from orders

### DIFF
--- a/src/api/docs/documentacionApi.ts
+++ b/src/api/docs/documentacionApi.ts
@@ -138,10 +138,7 @@ router.get("/apiv3/ordenes/byEmpresaPeriodoConDestinos/:idEmpresa/:fechaDesde/:f
  *         application/json:
  *           example:
  *             remito_number: "0001-00000001"
- *             remito_items:
- *               - IdOrden: 1
- *                 Cantidad: 1
- *                 Barcode: "PROD1"
+ *             # remito_items puede omitirse si la orden tiene partidas
  *     responses:
  *       200:
  *         description: Operación exitosa


### PR DESCRIPTION
## Summary
- load order details when creating remitos if no items provided
- set CAI data from punto de venta
- document optional `remito_items` when order has partidas

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68643190c79c832aad1f7a4cdf5100cb