### PR TITLE
Display public logo on remito PDF

### DIFF
--- a/src/config/pdfConfig.ts
+++ b/src/config/pdfConfig.ts
@@ -14,7 +14,8 @@ export const pdfConfig = {
     secondary: '#666666'
   },
   paths: {
-    logo: path.join(__dirname, '../../assets/logo.png'),
+    // logo image in public directory to be used on PDF generation
+    logo: path.join(process.cwd(), 'public', 'logo.png'),
     outputDir: path.join(process.cwd(), 'public', 'remitos')
   }
 };

--- a/src/services/pdfGenerator.ts
+++ b/src/services/pdfGenerator.ts
@@ -33,7 +33,7 @@ export class PDFGenerator {
     doc.text(`Número: ${remito.RemitoNumber}`);
     doc.text(`Fecha: ${formatDateTime(remito.Fecha)}`);
     if (remito.Empresa) {
-      doc.text(`Empresa: ${remito.Empresa.Nombre}`);
+      // doc.text(`Empresa: ${remito.Empresa.Nombre}`);
     }
     doc.moveDown();
 


### PR DESCRIPTION
## Summary
- update logo path to reference the file placed in the `public` directory
- stop printing the company name in the remito PDF

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6865deb805f8832a9d5a12f3478821be