### PR TITLE
Add remito lookup by number

### DIFF
--- a/src/DALC/remitos.dalc.ts
+++ b/src/DALC/remitos.dalc.ts
@@ -19,6 +19,14 @@ export const remito_getByOrden_DALC = async (idOrden: number) => {
     });
 };
 
+export const remito_getByNumero_DALC = async (numero: string) => {
+    const result = await getRepository(Remito).findOne({
+        where: { RemitoNumber: numero },
+        relations: ["Empresa", "PuntoVenta", "Items", "Items.Orden"],
+    });
+    return result;
+};
+
 export const remitos_getByEmpresa_DALC = async (
     idEmpresa: number,
     desde?: string,

--- a/src/api/docs/documentacionApi.ts
+++ b/src/api/docs/documentacionApi.ts
@@ -185,6 +185,25 @@ router.get("/apiv3/remitos/:id")
 
 /**
  * @openapi
+ * /apiv3/remitos/byNumero/{numero}:
+ *   get:
+ *     tags:
+ *       - Remitos
+ *     summary: Obtiene un remito por su número
+ *     parameters:
+ *       - name: numero
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ */
+router.get("/apiv3/remitos/byNumero/:numero")
+
+/**
+ * @openapi
  * /apiv3/remitos/byOrden/{idOrden}:
  *   get:
  *     tags:

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -4,6 +4,7 @@ import { orden_getById_DALC, orden_actualizarEstado_DALC } from "../DALC/ordenes
 import {
     remito_getById_DALC,
     remito_getByOrden_DALC,
+    remito_getByNumero_DALC,
     remitos_getByEmpresa_DALC,
     remito_crear_DALC,
     remito_actualizarEstado_DALC
@@ -154,6 +155,15 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
 export const getRemitoById = async (req: Request, res: Response): Promise<Response> => {
     const idRemito = Number(req.params.id);
     const remito = await remito_getById_DALC(idRemito);
+    if (!remito) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Remito inexistente"));
+    }
+    return res.json(require("lsi-util-node/API").getFormatedResponse(remito));
+};
+
+export const getRemitoByNumero = async (req: Request, res: Response): Promise<Response> => {
+    const numero = req.params.numero;
+    const remito = await remito_getByNumero_DALC(numero);
     if (!remito) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Remito inexistente"));
     }

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { crearRemitoDesdeOrden, getRemitoById, getRemitoByOrden, listRemitosByEmpresa, getHistoricoEstadosRemito, getRemitoPdf } from '../controllers/remitos.controller';
+import { crearRemitoDesdeOrden, getRemitoById, getRemitoByNumero, getRemitoByOrden, listRemitosByEmpresa, getHistoricoEstadosRemito, getRemitoPdf } from '../controllers/remitos.controller';
 
 const router = Router();
 const prefixAPI = '/apiv3';
@@ -8,6 +8,7 @@ router.post(`${prefixAPI}/remitos/fromOrden/:idOrden`, crearRemitoDesdeOrden);
 router.get(`${prefixAPI}/remitos/fromOrden/:idOrden`, getRemitoByOrden);
 router.get(`${prefixAPI}/remitos/:id`, getRemitoById);
 router.get(`${prefixAPI}/remitos/:id/pdf`, getRemitoPdf);
+router.get(`${prefixAPI}/remitos/byNumero/:numero`, getRemitoByNumero);
 router.get(`${prefixAPI}/remitos/byOrden/:idOrden`, getRemitoByOrden);
 router.get(`${prefixAPI}/remitos/byEmpresa/:idEmpresa/:desde?/:hasta?`, listRemitosByEmpresa);
 router.get(`${prefixAPI}/remitos/historico/:idRemito`, getHistoricoEstadosRemito);


### PR DESCRIPTION
## Summary
- allow retrieving a remito using its `RemitoNumber`
- expose controller/route `GET /apiv3/remitos/byNumero/:numero`
- document the new API route

## Testing
- `npm run build` *(fails: Cannot find module / type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68660aa12c30832aa6b0490195893c6f