### PR TITLE
Add endpoint to fetch order by number with items

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Ejemplo de respuesta:
     "Unidades": 10
   }
   ]
- ```
+```
+
+### GET /apiv3/ordenes/detalleOrdenByNumeroAndIdEmpresa/:numero/:idEmpresa
+
+Devuelve la orden indicada buscando por su número y empresa. Incluye los datos de la orden, su estado y el detalle de los ítems asociados.
 
 ### GET /apiv3/productos/allProductosByEmpresa/:IdEmpresa
 

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -355,6 +355,19 @@ export const getByNumeroAnIdEmpresa = async (req: Request, res: Response): Promi
     }
 }
 
+export const getDetalleOrdenByNumeroAnIdEmpresa = async (req: Request, res: Response): Promise<Response> => {
+    const orden = await orden_getByNumeroAndIdEmpresa_DALC(req.params.numero, parseInt(req.params.idEmpresa))
+    if (!orden) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente"))
+    }
+    const detalle = await ordenDetalle_getByIdOrden_DALC(orden.Id)
+    if (detalle==null) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Detalle inexistente"))
+    }
+    ;(orden as any).Detalle = detalle
+    return res.json(require("lsi-util-node/API").getFormatedResponse(orden))
+}
+
 
 
 

--- a/src/routes/ordenes.routes.ts
+++ b/src/routes/ordenes.routes.ts
@@ -23,6 +23,7 @@ import {
     getPendientes,
     setEstado,
     getByNumeroAnIdEmpresa,
+    getDetalleOrdenByNumeroAnIdEmpresa,
     eliminarOrden,
     getOrdenes,
     saleOrder,
@@ -49,6 +50,7 @@ router.get(prefixAPI+"/ordenes/detalleOrdenAndProductoById/:id", getDetalleOrden
 router.get(prefixAPI+"/ordenes/detalleOrdenAndProductoAndPartidaById/:id", getDetalleOrdenAndProductoAndPartidaById)
 router.get(prefixAPI+"/ordenes/detallePosicionesOrdenById/:id/:idEmpresa", getDetallePosicionesOrdenByID)
 router.get(prefixAPI+"/ordenes/byNumeroAndIdEmpresa/:numero/:idEmpresa", getByNumeroAnIdEmpresa)
+router.get(prefixAPI+"/ordenes/detalleOrdenByNumeroAndIdEmpresa/:numero/:idEmpresa", getDetalleOrdenByNumeroAnIdEmpresa)
 router.get(prefixAPI+"/ordenes/Destinos/:idEmpresa", getAllDestinoByIdEmpresa)
 router.get(prefixAPI+"/ordenes/byPeriodo/:fechaDesde/:fechaHasta", getByPeriodo)
 router.get(prefixAPI+"/ordenes/getCantByPeriodo/:fechaDesde/:fechaHasta", getCantByPeriodo)


### PR DESCRIPTION
## Summary
- add `getDetalleOrdenByNumeroAnIdEmpresa` controller to fetch an order by number with item details
- expose new route `/apiv3/ordenes/detalleOrdenByNumeroAndIdEmpresa/:numero/:idEmpresa`
- document the endpoint in README

## Testing
- `npm run build` *(fails: Cannot find name 'process', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_686fcbcaea50832a8a56fe8cf5e781fb