### PR TITLE
Add items to by-number order endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,17 @@ Ejemplo de respuesta:
     "Unidades": 10
   }
   ]
- ```
+```
+
+
+### GET /apiv3/ordenes/byNumeroAndIdEmpresa/:numero/:idEmpresa
+
+Devuelve la orden indicada buscando por su número y empresa. Incluye el estado,
+los datos del cliente y el detalle de los ítems asociados.
+Cada ítem contiene código de empresa, descripción, código de barras y, cuando la
+empresa maneja partidas, el número de partida.
+Además la respuesta agrega las banderas `TieneLote` y `TienePart` según la
+configuración de la empresa.
 
 ### GET /apiv3/productos/allProductosByEmpresa/:IdEmpresa
 

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -41,6 +41,7 @@ import { bultos_setByIdOrdenAndIdEmpresa,
          ordenDetalle_getByIdProducto_DALC,
          ordenDetalle_getByIdOrdenAndProductoAndPartida_DALC
 }from "../DALC/ordenesDetalle.dalc"
+import { destino_getById_DALC } from "../DALC/destinos.dalc"
 import { detallePosicion_getByIdProd_DALC } from "../DALC/posiciones.dalc"
 
 
@@ -346,13 +347,28 @@ export const getOrdenDetalleByIdProducto = async (req: Request, res: Response): 
 
 
 export const getByNumeroAnIdEmpresa = async (req: Request, res: Response): Promise <Response> => {
-    const result = await orden_getByNumeroAndIdEmpresa_DALC(req.params.numero, parseInt(req.params.idEmpresa))
+    const orden = await orden_getByNumeroAndIdEmpresa_DALC(req.params.numero, parseInt(req.params.idEmpresa))
 
-    if (result!=null) {
-        return res.json(require("lsi-util-node/API").getFormatedResponse(result))
-    } else {
+    if (!orden) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente"))
     }
+
+    const empresa = await empresa_getById_DALC(orden.IdEmpresa)
+    const destino = await destino_getById_DALC(orden.Eventual)
+
+    let detalle
+    if (empresa && empresa.PART) {
+        detalle = await ordenDetalle_getByIdOrdenAndProductoAndPartida_DALC(orden.Id)
+    } else {
+        detalle = await ordenDetalle_getByIdOrdenAndProducto_DALC(orden.Id)
+    }
+
+    ;(orden as any).Detalle = detalle ?? []
+    ;(orden as any).Cliente = destino?.Nombre ?? null
+    ;(orden as any).TieneLote = empresa?.LOTE ?? false
+    ;(orden as any).TienePart = empresa?.PART ?? false
+
+    return res.json(require("lsi-util-node/API").getFormatedResponse(orden))
 }
 
 


### PR DESCRIPTION
## Summary
- include order details in `getByNumeroAnIdEmpresa`
- remove unused `getDetalleOrdenByNumeroAndIdEmpresa` route and docs
- document that `/apiv3/ordenes/byNumeroAndIdEmpresa/:numero/:idEmpresa` now returns items
- include client info and product details in the by-number endpoint

## Testing
- `npm run build` *(fails: Cannot find name 'process', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686fcbcaea50832a8a56fe8cf5e781fb