### PR TITLE
Enhance order detail endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,37 @@ Ejemplo de respuesta:
   ]
 ```
 
+### GET /apiv3/ordenes/detalleOrdenByNumeroAndIdEmpresa/:numero/:idEmpresa
+
+Obtiene la información completa de una orden junto con el detalle de ítems. El
+objeto respuesta incluye datos de entrega y transporte como `CodigoPostalEntrega`
+y `Transporte`.
+
+Los elementos del detalle contienen los campos `CodeEmpresa`, `Barcode`,
+`Partida` y la descripción del producto.
+
+Ejemplo de respuesta abreviado:
+
+```json
+{
+  "Id": 10,
+  "Numero": "150",
+  "cliente": "Ejemplo SA",
+  "CodigoPostalEntrega": "1406",
+  "Transporte": "Expreso",
+  "Detalle": [
+    {
+      "IdOrdendetalle": 1,
+      "Productos": "Producto A",
+      "Barcode": "A123",
+      "CodeEmpresa": "PROD1",
+      "Partida": "P1",
+      "Unidades": 2
+    }
+  ]
+}
+```
+
 
 ### GET /apiv3/productos/allProductosByEmpresa/:IdEmpresa
 

--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -476,6 +476,14 @@ export const orden_getByNumeroAndIdEmpresa_DALC = async (Numero: string, IdEmpre
     return results
 }
 
+export const orden_getByNumeroAndIdEmpresaWithEmpresa_DALC = async (Numero: string, IdEmpresa: number) => {
+    const result = await getRepository(Orden).findOne({
+        where: { Numero, IdEmpresa },
+        relations: ["Empresa"]
+    })
+    return result
+}
+
 export const ordenes_getByPeriodo_DALC = async (fechaDesde: string, fechaHasta: string) => {
     fechaDesde+=" 00:00:00"
     fechaHasta+=" 23:59:59"

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -22,6 +22,7 @@ import {
      ordenes_getPendientes_DALC,
      orden_editEstado_DALC,
      orden_getByNumeroAndIdEmpresa_DALC,
+     orden_getByNumeroAndIdEmpresaWithEmpresa_DALC,
      orden_delete_DALC,
      ordenes_getOrdenes_DALC,
      ordenes_SalidaOrdenes_DALC,
@@ -359,16 +360,44 @@ export const getByNumeroAnIdEmpresa = async (req: Request, res: Response): Promi
 }
 
 export const getDetalleOrdenByNumeroAnIdEmpresa = async (req: Request, res: Response): Promise<Response> => {
-    const orden = await orden_getByNumeroAndIdEmpresa_DALC(req.params.numero, parseInt(req.params.idEmpresa))
+    const orden = await orden_getByNumeroAndIdEmpresaWithEmpresa_DALC(
+        req.params.numero,
+        parseInt(req.params.idEmpresa)
+    )
     if (!orden) {
-        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente"))
+        return res
+            .status(404)
+            .json(
+                require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente")
+            )
     }
-    const detalle = await ordenDetalle_getByIdOrden_DALC(orden.Id)
-    if (detalle==null) {
-        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Detalle inexistente"))
+
+    const detalle = await ordenDetalle_getByIdOrdenAndProductoAndPartida_DALC(orden.Id)
+    if (detalle == null) {
+        return res
+            .status(404)
+            .json(
+                require("lsi-util-node/API").getFormatedResponse("", "Detalle inexistente")
+            )
     }
-    ;(orden as any).Detalle = detalle
-    return res.json(require("lsi-util-node/API").getFormatedResponse(orden))
+
+    const respuesta = {
+        Id: orden.Id,
+        Numero: orden.Numero,
+        Fecha: orden.Fecha,
+        cliente: orden.Empresa?.RazonSocial ?? "",
+        DomicilioEntrega: orden.DomicilioEntrega,
+        CodigoPostalEntrega: orden.CodigoPostalEntrega,
+        Transporte: orden.Transporte,
+        DomicilioTransporte: orden.DomicilioTransporte,
+        CuitIvaTransporte: orden.CuitIvaTransporte,
+        OrdenCompra: orden.OrdenCompra,
+        NroPedidos: orden.NroPedidos,
+        ObservacionesLugarEntrega: orden.ObservacionesLugarEntrega,
+        Detalle: detalle
+    }
+
+    return res.json(require("lsi-util-node/API").getFormatedResponse(respuesta))
 }
 
 


### PR DESCRIPTION
## Summary
- add DALC helper to fetch order with company data
- expose transport and delivery info in order detail controller
- document `/apiv3/ordenes/detalleOrdenByNumeroAndIdEmpresa` response fields

## Testing
- `npm run build` *(fails: Cannot find name 'process', missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871a2536830832a8f1d38391db15749