### PR TITLE
Fix detalle order empty check

### DIFF
--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -373,7 +373,7 @@ export const getDetalleOrdenByNumeroAnIdEmpresa = async (req: Request, res: Resp
     }
 
     const detalle = await ordenDetalle_getByIdOrdenAndProductoAndPartida_DALC(orden.Id)
-    if (detalle == null) {
+    if (!detalle || detalle.length === 0) {
         return res
             .status(404)
             .json(


### PR DESCRIPTION
## Summary
- handle empty array check for `getDetalleOrdenByNumeroAnIdEmpresa`

## Testing
- `npm run build` *(fails: Cannot find name 'process', 'ts-node' not found)*
- `npm run test:pdf` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a433f47c832abd0c93996b7f8658