### PR TITLE
Add parameter validation for order lookup

### DIFF
--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -346,8 +346,32 @@ export const getOrdenDetalleByIdProducto = async (req: Request, res: Response): 
 
 
 
-export const getByNumeroAnIdEmpresa = async (req: Request, res: Response): Promise <Response> => {
-    const orden = await orden_getByNumeroAndIdEmpresa_DALC(req.params.numero, parseInt(req.params.idEmpresa))
+export const getByNumeroAnIdEmpresa = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    const { numero, idEmpresa } = req.params;
+
+    if (!numero) {
+        return res.status(400).json(
+            require('lsi-util-node/API').getFormatedResponse(
+                '',
+                'Parámetro numero inválido'
+            )
+        );
+    }
+
+    const idEmp = Number(idEmpresa);
+    if (isNaN(idEmp)) {
+        return res.status(400).json(
+            require('lsi-util-node/API').getFormatedResponse(
+                '',
+                'Parámetro idEmpresa inválido'
+            )
+        );
+    }
+
+    const orden = await orden_getByNumeroAndIdEmpresa_DALC(numero, idEmp)
 
     if (!orden) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Orden inexistente"))
@@ -359,10 +383,34 @@ export const getByNumeroAnIdEmpresa = async (req: Request, res: Response): Promi
     return res.json(require("lsi-util-node/API").getFormatedResponse(orden))
 }
 
-export const getDetalleOrdenByNumeroAnIdEmpresa = async (req: Request, res: Response): Promise<Response> => {
+export const getDetalleOrdenByNumeroAnIdEmpresa = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    const { numero, idEmpresa } = req.params;
+
+    if (!numero) {
+        return res.status(400).json(
+            require('lsi-util-node/API').getFormatedResponse(
+                '',
+                'Parámetro numero inválido'
+            )
+        );
+    }
+
+    const idEmp = Number(idEmpresa);
+    if (isNaN(idEmp)) {
+        return res.status(400).json(
+            require('lsi-util-node/API').getFormatedResponse(
+                '',
+                'Parámetro idEmpresa inválido'
+            )
+        );
+    }
+
     const orden = await orden_getByNumeroAndIdEmpresaWithEmpresa_DALC(
-        req.params.numero,
-        parseInt(req.params.idEmpresa)
+        numero,
+        idEmp
     )
     if (!orden) {
         return res


### PR DESCRIPTION
## Summary
- validate numero and idEmpresa params in order lookup endpoints

## Testing
- `npm run build` *(fails: Cannot find name 'process' and other Node types)*

------
https://chatgpt.com/codex/tasks/task_e_6871a6adcee4832a9a9d8e464f1aaaa5