### PR TITLE
Add support for CodigoPostalTransporte

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Ejemplo de respuesta:
 ### GET /apiv3/ordenes/detalleOrdenByNumeroAndIdEmpresa/:numero/:idEmpresa
 
 Obtiene la información completa de una orden junto con el detalle de ítems. El
-objeto respuesta incluye datos de entrega y transporte como `CodigoPostalEntrega`
-y `Transporte`.
+objeto respuesta incluye datos de entrega y transporte como `CodigoPostalEntrega`,
+`Transporte` y `codigoPostalTransporte`. También se informa el identificador
+`idOrden` y el `estado` de la orden.
 
 Los elementos del detalle contienen los campos `CodeEmpresa`, `Barcode`,
 `Partida` y la descripción del producto.
@@ -75,11 +76,13 @@ Ejemplo de respuesta abreviado:
 
 ```json
 {
-  "Id": 10,
-  "Numero": "150",
+  "idOrden": 10,
+  "comprobante": "150",
+  "estado": 1,
   "cliente": "Ejemplo SA",
-  "CodigoPostalEntrega": "1406",
-  "Transporte": "Expreso",
+  "codigoPostalEntrega": "1406",
+  "codigoPostalTransporte": "1406",
+  "transporte": "Expreso",
   "Detalle": [
     {
       "IdOrdendetalle": 1,

--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -103,6 +103,7 @@ export const orden_generarNueva = async (
     codigoPostalEntrega?: string,
     transporte?: string,
     domicilioTransporte?: string,
+    codigoPostalTransporte?: string,
     cuitIvaTransporte?: string,
     ordenCompra?: string,
     nroPedidos?: string,
@@ -380,6 +381,7 @@ export const orden_generarNueva = async (
         nuevaOrden.CodigoPostalEntrega = codigoPostalEntrega ?? ""
         nuevaOrden.Transporte = transporte ?? ""
         nuevaOrden.DomicilioTransporte = domicilioTransporte ?? ""
+        nuevaOrden.CodigoPostalTransporte = codigoPostalTransporte ?? ""
         nuevaOrden.CuitIvaTransporte = cuitIvaTransporte ?? ""
         nuevaOrden.OrdenCompra = ordenCompra ?? ""
         nuevaOrden.NroPedidos = nroPedidos ?? ""

--- a/src/api/docs/documentacionApi.ts
+++ b/src/api/docs/documentacionApi.ts
@@ -121,6 +121,38 @@ router.get("/apiv3/ordenes/byEmpresaPeriodoConDestinos/:idEmpresa/:fechaDesde/:f
 
 /**
  * @openapi
+ * /apiv3/ordenes/detalleOrdenByNumeroAndIdEmpresa/{numero}/{idEmpresa}:
+ *   get:
+ *     tags:
+ *       - Ordenes
+ *     summary: Obtiene una orden y su detalle por número y empresa
+ *     parameters:
+ *       - name: numero
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - name: idEmpresa
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Operación exitosa
+ *         content:
+ *           application/json:
+ *             example:
+ *               idOrden: 10
+ *               comprobante: "150"
+ *               estado: 1
+ *               codigoPostalTransporte: "1406"
+ *               Detalle: []
+ */
+router.get("/apiv3/ordenes/detalleOrdenByNumeroAndIdEmpresa/:numero/:idEmpresa")
+
+/**
+ * @openapi
  * /apiv3/remitos/fromOrden/{idOrden}:
  *   post:
  *     tags:

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -148,6 +148,7 @@ export const generarNueva = async (req: Request, res: Response): Promise<Respons
             "codigoPostalEntrega",
             "transporte",
             "domicilioTransporte",
+            "codigoPostalTransporte",
             "cuitIvaTransporte",
             "ordenCompra",
             "nroPedidos"
@@ -216,6 +217,7 @@ export const generarNueva = async (req: Request, res: Response): Promise<Respons
         codigoPostalEntrega,
         transporte,
         domicilioTransporte,
+        codigoPostalTransporte,
         cuitIvaTransporte,
         ordenCompra,
         nroPedidos,
@@ -253,6 +255,7 @@ export const generarNueva = async (req: Request, res: Response): Promise<Respons
             codigoPostalEntrega,
             transporte,
             domicilioTransporte,
+            codigoPostalTransporte,
             cuitIvaTransporte,
             ordenCompra,
             nroPedidos,
@@ -433,6 +436,7 @@ export const getDetalleOrdenByNumeroAnIdEmpresa = async (
     }
 
     const respuesta = {
+        idOrden: orden.Id,
         comprobante: orden.Numero,
         idEmpresa: orden.IdEmpresa,
         fecha: orden.Fecha,
@@ -445,6 +449,7 @@ export const getDetalleOrdenByNumeroAnIdEmpresa = async (
         codigoPostalEntrega: orden.CodigoPostalEntrega,
         transporte: orden.Transporte,
         domicilioTransporte: orden.DomicilioTransporte,
+        codigoPostalTransporte: orden.CodigoPostalTransporte,
         cuitIvaTransporte: orden.CuitIvaTransporte,
         ordenCompra: orden.OrdenCompra,
         nroPedidos: orden.NroPedidos,
@@ -455,6 +460,7 @@ export const getDetalleOrdenByNumeroAnIdEmpresa = async (
         preOrden: orden.PreOrden,
         kilos: orden.Kilos,
         metros: orden.Metros,
+        estado: orden.Estado,
         usuario: orden.UsuarioCreoOrd ?? orden.Usuario,
         Detalle: detalle
     }

--- a/src/entities/Orden.ts
+++ b/src/entities/Orden.ts
@@ -175,6 +175,9 @@ export class Orden {
     @Column({name: "domicilio_transporte", nullable: true})
     DomicilioTransporte: string
 
+    @Column({name: "codigo_postal_transporte", nullable: true})
+    CodigoPostalTransporte: string
+
     @Column({name: "cuit_iva_transporte", nullable: true})
     CuitIvaTransporte: string
 


### PR DESCRIPTION
## Summary
- include `codigo_postal_transporte` column in `Orden` entity
- allow creating orders with the new postal code
- expose order id, state and transport postal code in the detail endpoint
- document the updated endpoint in README and OpenAPI docs

## Testing
- `npm run build` *(fails: Cannot find name '__dirname' and other type errors)*
- `npm run test:pdf` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766d357598832ab43dfcc65d3edf3d