### PR TITLE
Handle errors gracefully

### DIFF
--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -859,7 +859,7 @@ export const orden_editEstado_DALC = async (orden: Orden, estado: number, usuari
 export const orden_actualizarEstado_DALC = async (idOrden: number, estado: number, usuario: string) => {
     const orden = await orden_getById_DALC(idOrden);
     if (!orden) {
-        throw new Error("Orden no encontrada");
+        return { estado: "ERROR", mensaje: "Orden no encontrada" };
     }
     return await orden_editEstado_DALC(orden, estado, usuario);
 };
@@ -1045,7 +1045,7 @@ export const ordenes_SalidaOrdenes_DALC = async (body: any) => {
             if (!producto) {
                 const errorMsg = `No se pudo encontrar el producto con barcode: ${registro.Barcode}`;
                 console.error(`[SALIDA_ORDEN] ${errorMsg}`);
-                throw new Error(errorMsg);
+                return { estado: "ERROR", mensaje: errorMsg };
             }
             console.log(`[SALIDA_ORDEN] Producto encontrado:`, {
                 id: producto.Id,
@@ -1232,7 +1232,7 @@ export const ordenes_SalidaOrdenes_DALC = async (body: any) => {
                     // Get the product to get its barcode
                     const producto = await producto_getByBarcodeAndEmpresa_DALC(String(unRegistro.Barcode), idEmpresa);
                     if (!producto) {
-                        throw new Error("No se pudo encontrar el producto con barcode: " + unRegistro.Barcode);
+                        return { estado: "ERROR", mensaje: "No se pudo encontrar el producto con barcode: " + unRegistro.Barcode };
                     }
                     const productos = await getProductoByPartidaAndEmpresaAndProducto_DALC(idEmpresa, unRegistro.partida, producto.Barcode)
 

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -268,11 +268,22 @@ export const actualizarEstadoRemito = async (req: Request, res: Response): Promi
                 const [ordenEstado] = estadoOrdenEntry;
                 
                 // Actualizar estado de la orden
-                await orden_actualizarEstado_DALC(
+                const ordenEstadoResult = await orden_actualizarEstado_DALC(
                     remito.Orden.Id,
                     parseInt(ordenEstado, 10),
                     usuario
                 );
+                if (
+                    ordenEstadoResult &&
+                    (ordenEstadoResult as any).estado === "ERROR"
+                ) {
+                    return res.status(404).json(
+                        require("lsi-util-node/API").getFormatedResponse(
+                            "",
+                            (ordenEstadoResult as any).mensaje
+                        )
+                    );
+                }
 
                 // Registrar la sincronización
                 await sincronizacionService.registrarSincronizacion(


### PR DESCRIPTION
## Summary
- avoid throwing errors in `ordenes.dalc` when an order or product is missing
- return error objects and adjust controller to send them as responses

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687ff130ae78832ab12130cfcfef4996