### PR TITLE
Fix TypeScript syntax error

### DIFF
--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -1457,7 +1457,6 @@ export const ordenes_SalidaOrdenes_DALC = async (body: any) => {
                 }
             }
         }
-    }
     
     console.log('[SALIDA_ORDEN] Proceso de salida de orden completado exitosamente');
     return orden;


### PR DESCRIPTION
## Summary
- remove a stray closing brace in `ordenes.dalc.ts`

## Testing
- `npm run build`
- `npm run test` *(fails: missing script)*
- `npm run test:pdf` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68854b3e4054832aaa5dbe1a6db1ebff