### PR TITLE
Add email entity mappings

### DIFF
--- a/src/entities/EmailServer.ts
+++ b/src/entities/EmailServer.ts
@@ -1,0 +1,31 @@
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm"
+
+@Entity("email_servers")
+export class EmailServer {
+    @PrimaryGeneratedColumn()
+    Id: number
+
+    @Column()
+    Nombre: string
+
+    @Column()
+    Host: string
+
+    @Column()
+    Puerto: number
+
+    @Column()
+    Usuario: string
+
+    @Column()
+    Password: string
+
+    @Column()
+    Seguro: boolean
+
+    @Column({ name: "desde_email" })
+    DesdeEmail: string
+
+    @Column({ name: "desde_nombre" })
+    DesdeNombre: string
+}

--- a/src/entities/EmailTemplate.ts
+++ b/src/entities/EmailTemplate.ts
@@ -1,0 +1,30 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm"
+import { EmailServer } from "./EmailServer"
+
+@Entity("email_templates")
+export class EmailTemplate {
+    @PrimaryGeneratedColumn()
+    Id: number
+
+    @Column({ name: "email_server_id" })
+    IdEmailServer: number
+
+    @ManyToOne(() => EmailServer)
+    @JoinColumn({ name: "email_server_id" })
+    Servidor: EmailServer
+
+    @Column()
+    Codigo: string
+
+    @Column()
+    Asunto: string
+
+    @Column({ type: "text", name: "cuerpo_html" })
+    CuerpoHtml: string
+
+    @Column({ type: "text", name: "cuerpo_texto" })
+    CuerpoTexto: string
+
+    @Column()
+    Activo: boolean
+}


### PR DESCRIPTION
## Summary
- add EmailServer entity
- add EmailTemplate entity using EmailServer

## Testing
- `npm run -s build` *(fails: Cannot find module 'typeorm' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6889666b8a30832a89d76d7794b7df93