### PR TITLE
Add DALC modules for email servers and templates

### DIFF
--- a/src/DALC/emailServers.dalc.ts
+++ b/src/DALC/emailServers.dalc.ts
@@ -1,0 +1,25 @@
+import { getRepository } from "typeorm";
+import { EmailServer } from "../entities/EmailServer";
+
+export const emailServer_getByEmpresa = async (idEmpresa: number) => {
+    return await getRepository(EmailServer).findOne({ where: { IdEmpresa: idEmpresa } as any });
+};
+
+export const emailServer_upsert = async (idEmpresa: number, data: Partial<EmailServer>) => {
+    const repo = getRepository(EmailServer);
+    let existente = await repo.findOne({ where: { IdEmpresa: idEmpresa } as any });
+    if (existente) {
+        await repo.update(existente.Id, data);
+        return await repo.findOne(existente.Id);
+    }
+    const nuevo = repo.create({ ...data, IdEmpresa: idEmpresa } as any);
+    return await repo.save(nuevo);
+};
+
+export const emailServer_delete = async (idEmpresa: number) => {
+    const repo = getRepository(EmailServer);
+    const existente = await repo.findOne({ where: { IdEmpresa: idEmpresa } as any });
+    if (existente) {
+        await repo.delete(existente.Id);
+    }
+};

--- a/src/DALC/emailTemplates.dalc.ts
+++ b/src/DALC/emailTemplates.dalc.ts
@@ -1,0 +1,22 @@
+import { getRepository } from "typeorm";
+import { EmailTemplate } from "../entities/EmailTemplate";
+
+export const template_getByTipo = async (codigo: string) => {
+    return await getRepository(EmailTemplate).findOne({ where: { Codigo: codigo } });
+};
+
+export const template_upsert = async (data: Partial<EmailTemplate>) => {
+    const repo = getRepository(EmailTemplate);
+    if (data.Id) {
+        await repo.update(data.Id, data);
+        return await repo.findOne(data.Id);
+    }
+    const nuevo = repo.create(data);
+    return await repo.save(nuevo);
+};
+
+export const template_activate = async (id: number, activo: boolean) => {
+    const repo = getRepository(EmailTemplate);
+    await repo.update(id, { Activo: activo } as any);
+    return await repo.findOne(id);
+};

--- a/src/entities/EmailServer.ts
+++ b/src/entities/EmailServer.ts
@@ -5,6 +5,9 @@ export class EmailServer {
     @PrimaryGeneratedColumn()
     Id: number
 
+    @Column({ name: "id_empresa" })
+    IdEmpresa: number
+
     @Column()
     Nombre: string
 


### PR DESCRIPTION
## Summary
- add DALC for email servers
- add DALC for email templates
- extend `EmailServer` entity with company id

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'typeorm' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688968b876ac832a823ad7f81472565f