### PR TITLE
Add email server/template controllers and routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "multer": "^1.4.5-lts.1",
         "mysql": "^2.18.1",
         "nanoid": "^3.1.23",
+        "nodemailer": "^6.9.3",
         "npm": "^7.21.0",
         "pdfkit": "^0.13.0",
         "swagger-jsdoc": "^6.2.8",
@@ -46,6 +47,7 @@
         "@types/morgan": "^1.9.2",
         "@types/multer": "^1.4.7",
         "@types/node": "^15.14.9",
+        "@types/nodemailer": "^6.4.7",
         "@types/pdfkit": "^0.12.7",
         "autoprefixer": "^10.4.21",
         "fs-extra": "^11.3.0",
@@ -1200,6 +1202,16 @@
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/pdfkit": {
       "version": "0.12.7",
@@ -4854,6 +4866,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-range": {
       "version": "0.1.2",
@@ -10700,6 +10721,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
+    "@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/pdfkit": {
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.12.7.tgz",
@@ -13467,6 +13497,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
+    },
+    "nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA=="
     },
     "normalize-range": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "tesseract.js": "^2.1.5",
     "typeorm": "^0.2.32",
     "winston": "^3.3.3",
-    "winston-daily-rotate-file": "^4.5.5"
+    "winston-daily-rotate-file": "^4.5.5",
+    "nodemailer": "^6.9.3"
   },
   "devDependencies": {
     "@types/basic-auth": "^1.1.3",
@@ -51,6 +52,7 @@
     "@types/multer": "^1.4.7",
     "@types/node": "^15.14.9",
     "@types/pdfkit": "^0.12.7",
+    "@types/nodemailer": "^6.4.7",
     "autoprefixer": "^10.4.21",
     "fs-extra": "^11.3.0",
     "postcss": "^8.5.6",

--- a/src/controllers/emailServers.controller.ts
+++ b/src/controllers/emailServers.controller.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from "express";
+import {
+    emailServer_getByEmpresa,
+    emailServer_upsert,
+    emailServer_delete
+} from "../DALC/emailServers.dalc";
+import { empresa_getById_DALC } from "../DALC/empresas.dalc";
+import nodemailer from "nodemailer";
+
+export const getByEmpresa = async (req: Request, res: Response): Promise<Response> => {
+    const empresa = await empresa_getById_DALC(Number(req.params.idEmpresa));
+    if (!empresa) {
+        return res.status(404).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Empresa inexistente")
+        );
+    }
+    const servidor = await emailServer_getByEmpresa(empresa.Id);
+    if (!servidor) {
+        return res.status(404).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Servidor inexistente")
+        );
+    }
+    return res.json(require("lsi-util-node/API").getFormatedResponse(servidor));
+};
+
+export const upsert = async (req: Request, res: Response): Promise<Response> => {
+    const empresa = await empresa_getById_DALC(Number(req.params.idEmpresa));
+    if (!empresa) {
+        return res.status(404).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Empresa inexistente")
+        );
+    }
+    const result = await emailServer_upsert(empresa.Id, req.body);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const eliminar = async (req: Request, res: Response): Promise<Response> => {
+    const empresa = await empresa_getById_DALC(Number(req.params.idEmpresa));
+    if (!empresa) {
+        return res.status(404).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Empresa inexistente")
+        );
+    }
+    const result = await emailServer_delete(empresa.Id);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const test = async (req: Request, res: Response): Promise<Response> => {
+    const empresa = await empresa_getById_DALC(Number(req.params.idEmpresa));
+    if (!empresa) {
+        return res.status(404).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Empresa inexistente")
+        );
+    }
+    const servidor = await emailServer_getByEmpresa(empresa.Id);
+    if (!servidor) {
+        return res.status(404).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Servidor inexistente")
+        );
+    }
+    try {
+        const transporter = nodemailer.createTransport({
+            host: servidor.Host,
+            port: servidor.Puerto,
+            secure: servidor.Seguro,
+            auth: { user: servidor.Usuario, pass: servidor.Password }
+        });
+        await transporter.sendMail({
+            from: `"${servidor.DesdeNombre}" <${servidor.DesdeEmail}>`,
+            to: req.body.to || servidor.Usuario,
+            subject: "Prueba de servidor de correo",
+            text: "Mensaje de prueba"
+        });
+        return res.json(
+            require("lsi-util-node/API").getFormatedResponse(true, "Email enviado")
+        );
+    } catch (error) {
+        console.error("Error enviando email de prueba", error);
+        return res.status(500).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Error enviando email de prueba")
+        );
+    }
+};

--- a/src/controllers/emailTemplates.controller.ts
+++ b/src/controllers/emailTemplates.controller.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+import {
+    template_getByTipo,
+    template_upsert,
+    template_activate
+} from "../DALC/emailTemplates.dalc";
+
+export const getByCodigo = async (req: Request, res: Response): Promise<Response> => {
+    const template = await template_getByTipo(req.params.codigo);
+    if (!template) {
+        return res.status(404).json(
+            require("lsi-util-node/API").getFormatedResponse("", "Plantilla inexistente")
+        );
+    }
+    return res.json(require("lsi-util-node/API").getFormatedResponse(template));
+};
+
+export const alta = async (req: Request, res: Response): Promise<Response> => {
+    const result = await template_upsert(req.body);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const editar = async (req: Request, res: Response): Promise<Response> => {
+    const result = await template_upsert({ ...req.body, Id: Number(req.params.id) });
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const activar = async (req: Request, res: Response): Promise<Response> => {
+    const result = await template_activate(
+        Number(req.params.id),
+        req.params.activo === "true"
+    );
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ import usuarios from './routes/usuarios.routes';
 import destinos from './routes/destinos.routes';
 import roles from './routes/roles.routes';
 import auditoriaRoutes from './routes/auditoria.routes';
+import emailServersRoutes from './routes/emailServers.routes';
+import emailTemplatesRoutes from './routes/emailTemplates.routes';
 
 import tiendaNubeRoutes from "./api/tiendanube/routes/tiendanube.routes";
 import yiqiRoutes from "./api/yiqi/routes/yiqi.routes";
@@ -76,6 +78,8 @@ app.use(visionGoogle)
 app.use(usuarios)
 app.use(destinos)
 app.use(roles)
+app.use(emailServersRoutes)
+app.use(emailTemplatesRoutes)
 app.use(auditoriaRoutes)
 
 

--- a/src/routes/emailServers.routes.ts
+++ b/src/routes/emailServers.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { getByEmpresa, upsert, eliminar, test } from '../controllers/emailServers.controller';
+
+const router = Router();
+const prefixAPI = '/apiv3';
+
+router.get(`${prefixAPI}/emailServer/:idEmpresa`, getByEmpresa);
+router.post(`${prefixAPI}/emailServer/:idEmpresa`, upsert);
+router.delete(`${prefixAPI}/emailServer/:idEmpresa`, eliminar);
+router.post(`${prefixAPI}/emailServer/test/:idEmpresa`, test);
+
+export default router;

--- a/src/routes/emailTemplates.routes.ts
+++ b/src/routes/emailTemplates.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { alta, editar, getByCodigo, activar } from '../controllers/emailTemplates.controller';
+
+const router = Router();
+const prefixAPI = '/apiv3';
+
+router.get(`${prefixAPI}/emailTemplate/:codigo`, getByCodigo);
+router.post(`${prefixAPI}/emailTemplate`, alta);
+router.patch(`${prefixAPI}/emailTemplate/:id`, editar);
+router.put(`${prefixAPI}/emailTemplate/activate/:id/:activo`, activar);
+
+export default router;


### PR DESCRIPTION
## Summary
- implement emailServers controller with CRUD and test email
- implement emailTemplates controller with management endpoints
- create routes for email servers and templates
- wire new routers in index
- add nodemailer deps

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68896a6126fc832aa574f62fe3c73966