### PR TITLE
Use new email service with templates

### DIFF
--- a/src/helpers/emailTemplates.ts
+++ b/src/helpers/emailTemplates.ts
@@ -1,0 +1,19 @@
+import { template_getByTipo } from '../DALC/emailTemplates.dalc'
+
+export const renderEmailTemplate = async (
+  codigo: string,
+  valores: Record<string, string>
+): Promise<{ asunto: string; cuerpo: string } | null> => {
+  const template = await template_getByTipo(codigo)
+  if (!template || !template.Activo) {
+    return null
+  }
+  let asunto = template.Asunto
+  let cuerpo = template.CuerpoHtml
+  for (const [k, v] of Object.entries(valores)) {
+    const regex = new RegExp(`{{\s*${k}\s*}}`, 'g')
+    asunto = asunto.replace(regex, v)
+    cuerpo = cuerpo.replace(regex, v)
+  }
+  return { asunto, cuerpo }
+}


### PR DESCRIPTION
## Summary
- integrate emailService in order, guide and stock DALCs
- support optional email templates when sending mails
- add helper to render email templates

## Testing
- `npm run build`
- `npm run test:pdf` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68896d6626b0832a91dad96085657a26