### PR TITLE
Load env variables for DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=username
+DB_PASSWORD=password
+DB_NAME=database

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,12 +1,17 @@
-import {  createConnection } from "typeorm";
+import { createConnection } from "typeorm";
+
+const DB_HOST = process.env.DB_HOST || "";
+const DB_USER = process.env.DB_USER || "";
+const DB_PASSWORD = process.env.DB_PASSWORD || "";
+const DB_NAME = process.env.DB_NAME || "";
 
 export const conectaProduccion = async () => {
     await createConnection({
         "type": "mysql",
-        "host": "localhost",
-        "username": "APIv3Prod",
-        "password": "APIv3Prod1512@!@",
-        "database": "godoy",
+        "host": DB_HOST,
+        "username": DB_USER,
+        "password": DB_PASSWORD,
+        "database": DB_NAME,
         "entities": ["dist/entities/**/*.js", "dist/entities/tiendanube/**/*.js"],
         "migrations": ["dist/migrations/**/*.js"],
         "synchronize": false,
@@ -19,10 +24,10 @@ export const conectaProduccion = async () => {
 export const conectaProduccionUniversal = async () => {
     await createConnection({
         "type": "mysql",
-        "host": "datosdemo01.areatech.site",
-        "username": "APIv3ProdUniversal",
-        "password": "APIv3ProdUniversal1512@!@",
-        "database": "godoy",
+        "host": DB_HOST,
+        "username": DB_USER,
+        "password": DB_PASSWORD,
+        "database": DB_NAME,
         "entities": ["dist/entities/**/*.js", "dist/entities/tiendanube/**/*.js"],
         "migrations": ["dist/migrations/**/*.js"],
         "synchronize": false,
@@ -35,10 +40,10 @@ export const conectaProduccionUniversal = async () => {
 export const conectaDesarrollo = async () => {
     return await createConnection({
         "type": "mysql",
-        "host": "datosdemo01.areatech.site",
-        "username": "APIv3Dev",
-        "password": "APIv3Dev!",
-        "database": "hermes_testing",
+        "host": DB_HOST,
+        "username": DB_USER,
+        "password": DB_PASSWORD,
+        "database": DB_NAME,
         "entities": ["dist/entities/**/*.js", "dist/entities/tiendanube/**/*.js"],
         "migrations": ["dist/migrations/**/*.js"],
         "synchronize": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@ const https = require("https")
 const { swaggerDocs } = require("./api/docs/swagger.js")
 
 import "reflect-metadata"
+import dotenv from 'dotenv'
+
+// Cargar variables de entorno desde .env
+dotenv.config()
 
 import express from 'express'
 import morgan from 'morgan'


### PR DESCRIPTION
## Summary
- load dotenv in `src/index.ts`
- use environment variables for DB credentials
- document required env vars in `.env.example`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68896f21b3ac832a9b9ef4c066c7411d