### PR TITLE
Implement email template CRUD and local image uploads

### DIFF
--- a/src/DALC/emailTemplates.dalc.ts
+++ b/src/DALC/emailTemplates.dalc.ts
@@ -36,3 +36,24 @@ export const template_activate = async (id: number, activo: boolean) => {
     });
     return await repo.findOne({ where: { Id: id } });
 };
+
+export const template_getAll = async () => {
+    return await getRepository(EmailTemplate).find();
+};
+
+export const template_getByEmpresa = async (idEmpresa: number) => {
+    return await getRepository(EmailTemplate).find({ where: { IdEmpresa: idEmpresa } });
+};
+
+export const template_getById = async (id: number) => {
+    return await getRepository(EmailTemplate).findOne({ where: { Id: id } });
+};
+
+export const template_delete = async (id: number) => {
+    const repo = getRepository(EmailTemplate);
+    const existing = await repo.findOne({ where: { Id: id } });
+    if (existing) {
+        await repo.delete(id);
+    }
+    return existing;
+};

--- a/src/helpers/emailUpload.ts
+++ b/src/helpers/emailUpload.ts
@@ -1,0 +1,20 @@
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+
+const uploadDir = path.join(__dirname, '../../public/email-images');
+if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+    destination: (_req, _file, cb) => {
+        cb(null, uploadDir);
+    },
+    filename: (_req, file, cb) => {
+        const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+        cb(null, unique + path.extname(file.originalname));
+    }
+});
+
+export default multer({ storage });

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ const app = express()
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ limit: '10mb', extended: true }));
 app.use('/remitos', express.static(path.join(__dirname, '../public/remitos')));
+app.use('/email-images', express.static(path.join(__dirname, '../public/email-images')));
 
 // Servir archivos estáticos de la carpeta assets (en producción/compilación)
 const staticAssetsPath = fs.existsSync(path.join(__dirname, '../dist/assets')) 

--- a/src/routes/emailTemplates.routes.ts
+++ b/src/routes/emailTemplates.routes.ts
@@ -1,19 +1,41 @@
 import { Router } from 'express';
-import { alta, editar, getByTipo, activar } from '../controllers/emailTemplates.controller';
+import {
+    alta,
+    editar,
+    getByTipo,
+    activar,
+    getAll,
+    getByEmpresa,
+    eliminar,
+    uploadImagen
+} from '../controllers/emailTemplates.controller';
+import upload from '../helpers/emailUpload';
 
 const router = Router();
 const prefixAPI = '/apiv3';
+
+// Listar todas las plantillas
+router.get(`${prefixAPI}/emailTemplates`, getAll);
+
+// Obtener plantillas por empresa
+router.get(`${prefixAPI}/emailTemplates/byEmpresa/:idEmpresa`, getByEmpresa);
 
 // Obtener plantilla por tipo
 router.get(`${prefixAPI}/emailTemplate/:tipo`, getByTipo);
 
 // Crear nueva plantilla
-router.post(`${prefixAPI}/emailTemplate`, alta);
+router.post(`${prefixAPI}/emailTemplates`, alta);
 
 // Actualizar plantilla existente
-router.patch(`${prefixAPI}/emailTemplate/:id`, editar);
+router.patch(`${prefixAPI}/emailTemplates/:id`, editar);
 
 // Activar/desactivar plantilla
-router.put(`${prefixAPI}/emailTemplate/activate/:id/:activo`, activar);
+router.patch(`${prefixAPI}/emailTemplates/:id/activate/:activo`, activar);
+
+// Eliminar plantilla
+router.delete(`${prefixAPI}/emailTemplates/:id`, eliminar);
+
+// Subir imagen para plantilla
+router.post(`${prefixAPI}/emailTemplates/upload`, upload.single('image'), uploadImagen);
 
 export default router;


### PR DESCRIPTION
## Summary
- add helper for image uploads to `public/email-images`
- expose `email-images` folder as static assets
- extend DALC and controllers for email templates CRUD
- update routes to provide listing, per-company lookup, deletion, activation, and image upload

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run test:pdf` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_688afed5d3cc832a8b0d6ec2b06a4442