### PR TITLE
Centralize auth logic for email controllers

### DIFF
--- a/src/controllers/emailServers.controller.ts
+++ b/src/controllers/emailServers.controller.ts
@@ -6,41 +6,7 @@ import {
 } from "../DALC/emailServers.dalc";
 import { empresa_getById_DALC } from "../DALC/empresas.dalc";
 import nodemailer from "nodemailer";
-
-// Función auxiliar para manejar la autenticación
-const handleAuth = (req: Request) => {
-    const authHeader = req.headers.authorization;
-    
-    // Si hay header de autenticación básica
-    if (authHeader && authHeader.startsWith('Basic ')) {
-        const base64Credentials = authHeader.split(' ')[1];
-        const credentials = Buffer.from(base64Credentials, 'base64').toString('ascii');
-        const [usernameBasic, password] = credentials.split(':');
-
-        // Credenciales permitidas
-        const validCredentials = [
-            ['A54APIDev', 'A54API4470Dev!'],
-            ['A54APIProd', 'A54API4470Prod!'],
-            ['A54APIProdUniversal', 'A54API4470ProdUniversal!']
-        ];
-
-        const isValid = validCredentials.some(([user, pass]) => user === usernameBasic && pass === password);
-
-        if (isValid) {
-            return { idEmpresa: 259, username: 'sistema' };
-        }
-        throw new Error('Credenciales inválidas');
-    }
-    // Si hay usuario autenticado vía JWT
-    else if (req.user) {
-        return { 
-            idEmpresa: req.user.idEmpresa, 
-            username: req.user.username 
-        };
-    }
-    
-    throw new Error('Se requiere autenticación');
-};
+import { handleAuth } from "../helpers/auth";
 
 export const getByEmpresa = async (req: Request, res: Response): Promise<Response> => {
     try {

--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -1,0 +1,41 @@
+import { Request } from 'express';
+
+/**
+ * Maneja la autenticación tanto para Basic Auth como para JWT.
+ * @param req Request de Express
+ * @returns Objeto con idEmpresa y username extraídos de la autenticación
+ * @throws Error si la autenticación es inválida o inexistente
+ */
+export const handleAuth = (req: Request): { idEmpresa: number; username: string } => {
+    const authHeader = req.headers.authorization;
+
+    // Si hay header de autenticación básica
+    if (authHeader && authHeader.startsWith('Basic ')) {
+        const base64Credentials = authHeader.split(' ')[1];
+        const credentials = Buffer.from(base64Credentials, 'base64').toString('ascii');
+        const [usernameBasic, password] = credentials.split(':');
+
+        // Credenciales permitidas
+        const validCredentials = [
+            ['A54APIDev', 'A54API4470Dev!'],
+            ['A54APIProd', 'A54API4470Prod!'],
+            ['A54APIProdUniversal', 'A54API4470ProdUniversal!'],
+        ];
+
+        const isValid = validCredentials.some(([user, pass]) => user === usernameBasic && pass === password);
+
+        if (isValid) {
+            return { idEmpresa: 259, username: 'sistema' };
+        }
+        throw new Error('Credenciales inválidas');
+    }
+    // Si hay usuario autenticado vía JWT
+    if (req.user) {
+        return {
+            idEmpresa: req.user.idEmpresa,
+            username: req.user.username,
+        };
+    }
+
+    throw new Error('Se requiere autenticación');
+};


### PR DESCRIPTION
## Summary
- add shared `handleAuth` helper
- refactor email server controller to use the helper
- update email templates controller to rely on the shared helper

## Testing
- `npm run build`
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_688c275cc8c4832aa415771f28ea0ab5