### PR TITLE
Fix email datetime handling

### DIFF
--- a/src/entities/MailSaliente.ts
+++ b/src/entities/MailSaliente.ts
@@ -37,7 +37,7 @@ export class MailSaliente {
     @Column()
     EmailRemitente: string
 
-    @Column()
-    FechaEnvio: string
+    @Column({ type: 'datetime' })
+    FechaEnvio: Date
 
 }

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -72,7 +72,7 @@ export class EmailService {
       EmailRemitente: fromEmail,
       Enviado: false,
       CantidadIntentos: 0,
-      FechaEnvio: ''
+      FechaEnvio: new Date()
     })
 
     try {
@@ -82,7 +82,7 @@ export class EmailService {
       registro.Enviado = false
     } finally {
       registro.CantidadIntentos += 1
-      registro.FechaEnvio = new Date().toISOString()
+      registro.FechaEnvio = new Date()
       await repo.save(registro)
     }
 


### PR DESCRIPTION
## Summary
- store `MailSaliente.FechaEnvio` as a MySQL datetime
- use `Date` objects when persisting mail records

## Testing
- `npm run build`
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_688c4d7018d4832ab362b6033847ea58