### PR TITLE
Add endpoint for resending remito emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ GET /apiv3/remitos/10/pdf
 
 El contenido se envía con `Content-Type: application/pdf`.
 
+### POST /apiv3/remitos/enviarMail
+
+Permite reenviar por correo un remito existente. Debe enviarse en el cuerpo JSON
+con el identificador del remito:
+
+```json
+{
+  "IdRemito": "11"
+}
+```
+
+Opcionalmente se pueden incluir `Remitente` y `NombreRemitente` para
+sobrescribir el remitente configurado.
+
 ## Migraciones
 
 Despues de compilar el proyecto con `npm run build` es posible ejecutar las migraciones de base de datos con el comando:

--- a/src/routes/remitos.routes.ts
+++ b/src/routes/remitos.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { crearRemitoDesdeOrden, getRemitoById, getRemitoByNumero, getRemitoByOrden, listRemitosByEmpresa, getHistoricoEstadosRemito, getRemitoPdf } from '../controllers/remitos.controller';
+import { crearRemitoDesdeOrden, getRemitoById, getRemitoByNumero, getRemitoByOrden, listRemitosByEmpresa, getHistoricoEstadosRemito, getRemitoPdf, enviarMailRemito } from '../controllers/remitos.controller';
 
 const router = Router();
 const prefixAPI = '/apiv3';
@@ -12,5 +12,6 @@ router.get(`${prefixAPI}/remitos/byNumero/:numero`, getRemitoByNumero);
 router.get(`${prefixAPI}/remitos/byOrden/:idOrden`, getRemitoByOrden);
 router.get(`${prefixAPI}/remitos/byEmpresa/:idEmpresa/:desde?/:hasta?`, listRemitosByEmpresa);
 router.get(`${prefixAPI}/remitos/historico/:idRemito`, getHistoricoEstadosRemito);
+router.post(`${prefixAPI}/remitos/enviarMail`, enviarMailRemito);
 
 export default router;


### PR DESCRIPTION
## Summary
- add `enviarMailRemito` controller to send or resend remito email
- expose POST `/apiv3/remitos/enviarMail` route
- document the new endpoint in README

## Testing
- `npm run build`
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_688c548560b0832a8ec5a7a340dcc12d