### PR TITLE
feat: add plural email template route

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ El sistema permite definir servidores y plantillas de correo por empresa y proce
    - `Activo`
 2. Puede listar y actualizar configuraciones con los endpoints `GET /apiv3/emailProcesoConfig/:idEmpresa` y `PATCH /apiv3/emailProcesoConfig/:id`.
 3. Al enviar correos, los procesos consultan esta configuración para utilizar los servidores, plantillas y destinatarios definidos.
+4. Para obtener una plantilla específica puede usar `GET /apiv3/emailTemplate/:tipo`. También está disponible el alias `GET /apiv3/emailTemplates/:tipo` para compatibilidad.
 
 **Edit a file, create a new file, and clone from Bitbucket in under 2 minutes**
 

--- a/src/routes/emailTemplates.routes.ts
+++ b/src/routes/emailTemplates.routes.ts
@@ -50,6 +50,8 @@ router.get(`${prefixAPI}/emailTemplates/byEmpresa/:idEmpresa`, getByEmpresa);
 
 // Obtener plantilla por tipo
 router.get(`${prefixAPI}/emailTemplate/:tipo`, getByTipo);
+// Alias plural para compatibilidad
+router.get(`${prefixAPI}/emailTemplates/:tipo`, getByTipo);
 
 // Crear nueva plantilla
 router.post(`${prefixAPI}/emailTemplates`, alta);


### PR DESCRIPTION
## Summary
- support `/apiv3/emailTemplates/:tipo` as an alias for the existing single template path
- document how to fetch templates by type using both singular and plural routes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688da3d3b9d4832aae5bc293bcd2e4ac