### PR TITLE
Permitir remitente opcional en envío de remitos

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ con el identificador del remito:
 }
 ```
 
-Opcionalmente se pueden incluir `Remitente` y `NombreRemitente` para
-sobrescribir el remitente configurado.
+Por defecto se utilizarán los valores `FromEmail` y `FromName` del servidor de
+correo configurado. Los campos `Remitente` y `NombreRemitente` son opcionales y
+sólo deben enviarse si se desea sobrescribir esos valores.
 
 ## Migraciones
 

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -464,17 +464,24 @@ export const enviarMailRemito = async (req: Request, res: Response): Promise<Res
     }
 
     if (plantilla && destinatarios) {
-        await emailService.sendEmail({
+        const opcionesCorreo: any = {
             idEmpresa: empresa.Id,
             destinatarios,
             titulo: plantilla.asunto,
             cuerpo: plantilla.cuerpo,
             adjuntos: [{ filename: `remito-${remito.RemitoNumber}.pdf`, path: tempPath }],
-            emailRemitente: Remitente,
-            nombreRemitente: NombreRemitente,
             idEmailServer: config?.IdEmailServer,
             idEmailTemplate: config?.IdEmailTemplate
-        });
+        };
+
+        if (Remitente) {
+            opcionesCorreo.emailRemitente = Remitente;
+        }
+        if (NombreRemitente) {
+            opcionesCorreo.nombreRemitente = NombreRemitente;
+        }
+
+        await emailService.sendEmail(opcionesCorreo);
     }
     } catch (error) {
         console.error('[REMITO] Error al enviar remito por email:', error);


### PR DESCRIPTION
## Resumen
- Hacer opcionales los campos Remitente y NombreRemitente al reenviar remitos por correo, utilizando los valores de FromEmail/FromName configurados en el servidor cuando no se proveen
- Documentar el comportamiento por defecto del remitente en el README

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run test:pdf` *(falla: Cannot find module './remitoPdf.test.ts')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ebb69aabc832ab8d4a7b75884a96d