### PR TITLE
fix: enforce STARTTLS for Gmail

### DIFF
--- a/requests/emailServers.rest
+++ b/requests/emailServers.rest
@@ -1,0 +1,20 @@
+### Crear/actualizar servidor de correo (Gmail 587 STARTTLS)
+POST http://localhost:3000/apiv3/emailServer/:idEmpresa
+Content-Type: application/json
+Authorization: Bearer <TOKEN>
+
+{
+  "Host": "smtp.gmail.com",
+  "Port": 587,
+  "Username": "usuario@gmail.com",
+  "Password": "********",
+  "FromName": "Nombre Prueba",
+  "FromEmail": "usuario@gmail.com"
+}
+
+### Probar envío con configuración guardada
+POST http://localhost:3000/apiv3/emailServer/test/:idEmpresa
+Content-Type: application/json
+Authorization: Bearer <TOKEN>
+
+{}

--- a/src/controllers/emailServers.controller.ts
+++ b/src/controllers/emailServers.controller.ts
@@ -98,9 +98,14 @@ export const upsert = async (req: Request, res: Response): Promise<Response> => 
         const finalPort = parseInt(Puerto || portFromBody, 10) || 587;
         const finalUsername = Usuario || Username;
         const finalPassword = Password;
-        const finalSecure = Boolean(SSL || secureFromBody);
+        let finalSecure = Boolean(SSL || secureFromBody);
         const finalFromName = NombreDesde || FromName || finalUsername;
         const finalFromEmail = EmailDesde || FromEmail || finalUsername;
+
+        // Gmail con puerto 587 requiere STARTTLS (secure = false)
+        if (finalHost && finalHost.toLowerCase().includes('gmail') && finalPort === 587) {
+            finalSecure = false;
+        }
         
         console.log('Datos recibidos del frontend (crudos):', JSON.stringify(req.body, null, 2));
         console.log('Datos procesados:', {
@@ -267,7 +272,7 @@ export const test = async (req: Request, res: Response): Promise<Response> => {
         console.log('Enviando correo de prueba...');
         const info = await transporter.sendMail({
             from: `"${servidor.FromName}" <${servidor.FromEmail}>`,
-            to: req.body.to || servidor.Username,
+            to: req.body?.to || servidor.Username,
             subject: "Prueba de servidor de correo",
             text: "Este es un mensaje de prueba enviado desde el sistema de gestión.",
             html: `


### PR DESCRIPTION
## Summary
- ensure Gmail SMTP on port 587 is stored with Secure=false (STARTTLS)
- allow `/emailServer/test` to run without a request body
- add REST client examples for email server setup and test

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_688ebcd20658832ab85850c66bd10dc1