### PR TITLE
feat: soportar multiples destinatarios y override de prueba

### DIFF
--- a/src/DALC/movimientos.dalc.ts
+++ b/src/DALC/movimientos.dalc.ts
@@ -527,6 +527,8 @@ export const informar_IngresoStock_DALC = async (body: any) => {
                 let destinatarios = empresa.ContactoDeposito
                 if (config?.Destinatarios) {
                     destinatarios = config.Destinatarios
+                } else if (body.destinatarioTest) {
+                    destinatarios = body.destinatarioTest
                 }
 
                 await emailService.sendEmail({

--- a/src/DALC/ordenes.dalc.ts
+++ b/src/DALC/ordenes.dalc.ts
@@ -35,7 +35,7 @@ export const orden_getDetalleByOrden = async (orden: Orden) => {
 }
 
 
-export const orden_informarEmisionEtiqueta = async (orden: Orden) => {
+export const orden_informarEmisionEtiqueta = async (orden: Orden, destinatarioTest?: string) => {
     if (!orden.EmailAvisoImpresionEtiquetasEnviado) {
         const valores = {
             numeroOrden: String(orden.Numero),
@@ -58,6 +58,8 @@ export const orden_informarEmisionEtiqueta = async (orden: Orden) => {
         let destinatarios = 'almacenaje@area54sa.com.ar'
         if (config?.Destinatarios) {
             destinatarios = config.Destinatarios
+        } else if (destinatarioTest) {
+            destinatarios = destinatarioTest
         }
 
         await emailService.sendEmail({

--- a/src/controllers/ordenes.controller.ts
+++ b/src/controllers/ordenes.controller.ts
@@ -54,7 +54,7 @@ export const informarEmisionEtiqueta = async (req: Request, res: Response): Prom
         return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "Id orden inexistente"))
     }
 
-    const response=await orden_informarEmisionEtiqueta(orden)
+    const response=await orden_informarEmisionEtiqueta(orden, req.body.destinatarioTest)
 
     return res.json(require("lsi-util-node/API").getFormatedResponse(response))
 

--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -190,6 +190,8 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
             .join(',');
         if (config?.Destinatarios) {
             destinatarios = config.Destinatarios;
+        } else if (req.body.destinatarioTest) {
+            destinatarios = req.body.destinatarioTest;
         }
 
         console.log('[REMITO] Enviar a:', destinatarios, 'con valores:', valores);
@@ -461,6 +463,8 @@ export const enviarMailRemito = async (req: Request, res: Response): Promise<Res
         .join(',');
     if (config?.Destinatarios) {
         destinatarios = config.Destinatarios;
+    } else if (req.body.destinatarioTest) {
+        destinatarios = req.body.destinatarioTest;
     }
 
     if (plantilla && destinatarios) {


### PR DESCRIPTION
## Summary
- manejar Destinatarios separados por coma en envíos de guías
- permitir `destinatarioTest` cuando la regla no define destinatarios

## Testing
- `npm run build`
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_688eda153e7c832ab7b4d225b54c124d