### PR TITLE
fix: actualizar proceso de envío de remito

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ El sistema permite definir servidores y plantillas de correo por empresa y proce
 
 1. Cree una configuración con el endpoint `POST /apiv3/emailProcesoConfig` indicando:
    - `IdEmpresa`
-   - `Proceso` (identificador del proceso que enviará correos)
+   - `Proceso` (identificador del proceso que enviará correos). Los valores permitidos son los definidos en `EMAIL_PROCESOS`:
+     `ENVIO_REMITO`, `GUIA_TRACKING`, `ORDEN_ETIQUETA` e `INGRESO_STOCK`.
    - `IdEmailServer` e `IdEmailTemplate` opcionales
    - `Destinatarios` separados por coma
    - `Activo`

--- a/src/migrations/170-update-envio-remito-proceso.ts
+++ b/src/migrations/170-update-envio-remito-proceso.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateEnvioRemitoProceso170 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "UPDATE email_proceso_config SET Proceso = 'ENVIO_REMITO' WHERE Proceso = 'ENVIAR_REMITO'"
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "UPDATE email_proceso_config SET Proceso = 'ENVIAR_REMITO' WHERE Proceso = 'ENVIO_REMITO'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- documentar valores permitidos para `Proceso` al crear reglas de email
- migrar registros existentes de `email_proceso_config` de `ENVIAR_REMITO` a `ENVIO_REMITO`

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run test:pdf` *(falla: Cannot find module './remitoPdf.test.ts')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ee741ec00832a9a923e09cae66848