### PR TITLE
feat: add email server and template columns

### DIFF
--- a/src/entities/MailSaliente.ts
+++ b/src/entities/MailSaliente.ts
@@ -40,10 +40,10 @@ export class MailSaliente {
     @Column({ type: 'datetime' })
     FechaEnvio: Date
 
-    @Column({ nullable: true })
+    @Column({ type: 'int', nullable: true })
     IdEmailServer?: number
 
-    @Column({ nullable: true })
+    @Column({ type: 'int', nullable: true })
     IdEmailTemplate?: number
 
 }

--- a/src/migrations/171-add-email-columns-mailssalientes.ts
+++ b/src/migrations/171-add-email-columns-mailssalientes.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddEmailColumnsMailssalientes171 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            "mailssalientes",
+            new TableColumn({
+                name: "IdEmailServer",
+                type: "int",
+                isNullable: true,
+            })
+        );
+
+        await queryRunner.addColumn(
+            "mailssalientes",
+            new TableColumn({
+                name: "IdEmailTemplate",
+                type: "int",
+                isNullable: true,
+            })
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("mailssalientes", "IdEmailTemplate");
+        await queryRunner.dropColumn("mailssalientes", "IdEmailServer");
+    }
+}


### PR DESCRIPTION
## Summary
- specify int email server and template columns on MailSaliente entity
- add migration to create email server/template columns for mailssalientes table

## Testing
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eea63fbf8832a916493f63f9afe70