### PR TITLE
feat: add emailProcesoConfig test endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ El sistema permite definir servidores y plantillas de correo por empresa y proce
    - `Destinatarios` separados por coma
    - `Activo`
 2. Puede listar y actualizar configuraciones con los endpoints `GET /apiv3/emailProcesoConfig/:idEmpresa` y `PATCH /apiv3/emailProcesoConfig/:id`.
-3. Al enviar correos, los procesos consultan esta configuración para utilizar los servidores, plantillas y destinatarios definidos.
-4. Para obtener una plantilla específica puede usar `GET /apiv3/emailTemplate/:tipo`. También está disponible el alias `GET /apiv3/emailTemplates/:tipo` para compatibilidad.
+3. Puede probar una configuración con `POST /apiv3/emailProcesoConfig/:id/probar`. Si la regla no define `Destinatarios`, envíe `destinatarioTest` en el cuerpo de la solicitud.
+4. Al enviar correos, los procesos consultan esta configuración para utilizar los servidores, plantillas y destinatarios definidos.
+5. Para obtener una plantilla específica puede usar `GET /apiv3/emailTemplate/:tipo`. También está disponible el alias `GET /apiv3/emailTemplates/:tipo` para compatibilidad.
 
 **Edit a file, create a new file, and clone from Bitbucket in under 2 minutes**
 

--- a/src/DALC/emailProcesoConfig.dalc.ts
+++ b/src/DALC/emailProcesoConfig.dalc.ts
@@ -13,6 +13,10 @@ export const emailProcesoConfig_get = async (idEmpresa: number, proceso: string 
     return await getRepository(EmailProcesoConfig).findOne({ where: { IdEmpresa: idEmpresa, Proceso: In(procesos) } as any });
 };
 
+export const emailProcesoConfig_getById = async (id: number) => {
+    return await getRepository(EmailProcesoConfig).findOne({ where: { Id: id } });
+};
+
 export const emailProcesoConfig_upsert = async (data: Partial<EmailProcesoConfig>) => {
     const repo = getRepository(EmailProcesoConfig);
     const now = new Date();

--- a/src/routes/emailProcesoConfig.routes.ts
+++ b/src/routes/emailProcesoConfig.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { getByEmpresa, crear, editar, eliminar } from '../controllers/emailProcesoConfig.controller';
+import { getByEmpresa, crear, editar, eliminar, probar } from '../controllers/emailProcesoConfig.controller';
 
 const router = Router();
 const prefixAPI = '/apiv3';
@@ -8,5 +8,6 @@ router.get(`${prefixAPI}/emailProcesoConfig/:idEmpresa`, getByEmpresa);
 router.post(`${prefixAPI}/emailProcesoConfig`, crear);
 router.patch(`${prefixAPI}/emailProcesoConfig/:id`, editar);
 router.delete(`${prefixAPI}/emailProcesoConfig/:id`, eliminar);
+router.post(`${prefixAPI}/emailProcesoConfig/:id/probar`, probar);
 
 export default router;


### PR DESCRIPTION
## Summary
- add `POST /apiv3/emailProcesoConfig/:id/probar` to send test emails
- allow `destinatarioTest` fallback when config has no recipients
- document the new endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688eec9db084832a9a3f35377938f640