### PR TITLE
Log email server details for remitos

### DIFF
--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -197,6 +197,14 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
         console.log('[REMITO] Enviar a:', destinatarios, 'con valores:', valores);
 
         if (plantilla && destinatarios) {
+            console.log(
+                '[REMITO] Email config - IdEmailServer:',
+                config?.IdEmailServer,
+                'IdEmailTemplate:',
+                config?.IdEmailTemplate,
+                'Proceso:',
+                config?.Proceso
+            );
             await emailService.sendEmail({
                 idEmpresa: empresa.Id,
                 destinatarios,

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -53,6 +53,12 @@ export class EmailService {
     const fromEmail = options.emailRemitente || cfg.DesdeEmail || cfg.FromEmail
     const fromName = options.nombreRemitente || cfg.DesdeNombre || cfg.FromName
 
+    console.log('[EmailService] SMTP server', {
+      host,
+      port,
+      serverId: servidor?.Id
+    })
+
     const transporter = nodemailer.createTransport({
       host,
       port,


### PR DESCRIPTION
## Summary
- log email configuration (server, template, process) before sending remito emails
- log SMTP host, port, and server id in email service for server identification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fd1ebf8a8832a906202f0e19aff80