### PR TITLE
chore: log rendered email template

### DIFF
--- a/src/controllers/remitos.controller.ts
+++ b/src/controllers/remitos.controller.ts
@@ -181,6 +181,9 @@ export const crearRemitoDesdeOrden = async (req: Request, res: Response): Promis
 
         const config = await emailProcesoConfig_get(empresa.Id, EMAIL_PROCESOS.ENVIO_REMITO);
         const plantilla = await renderEmailTemplate(EMAIL_PROCESOS.ENVIO_REMITO, valores, config?.IdEmailTemplate);
+        if (plantilla) {
+            console.log('[REMITO] Plantilla renderizada:', plantilla);
+        }
 
         let destinatarios = [
             empresa.ContactoDeposito,
@@ -462,6 +465,9 @@ export const enviarMailRemito = async (req: Request, res: Response): Promise<Res
 
     const config = await emailProcesoConfig_get(empresa.Id, EMAIL_PROCESOS.ENVIO_REMITO);
     const plantilla = await renderEmailTemplate(EMAIL_PROCESOS.ENVIO_REMITO, valores, config?.IdEmailTemplate);
+    if (plantilla) {
+        console.log('[REMITO] Plantilla renderizada:', plantilla);
+    }
 
     let destinatarios = [
         empresa.ContactoDeposito,


### PR DESCRIPTION
## Summary
- log the rendered email template in remito controller to inspect final subject and body

## Testing
- `npm test` *(fails: Missing script "test")*
- `node` template replacement demo

------
https://chatgpt.com/codex/tasks/task_e_688fd385c93c832aa3192feba6d111f0