### PR TITLE
chore: log email server lookup

### DIFF
--- a/src/DALC/emailServers.dalc.ts
+++ b/src/DALC/emailServers.dalc.ts
@@ -2,7 +2,10 @@ import { getRepository } from "typeorm";
 import { EmailServer } from "../entities/EmailServer";
 
 export const emailServer_getByEmpresa = async (idEmpresa: number) => {
-    return await getRepository(EmailServer).findOne({ where: { IdEmpresa: idEmpresa } as any });
+    console.log('[EmailServerDALC] Buscando servidor para empresa', idEmpresa);
+    const servidor = await getRepository(EmailServer).findOne({ where: { IdEmpresa: idEmpresa } as any });
+    console.log('[EmailServerDALC] Servidor encontrado', { Id: servidor?.Id, Host: servidor?.Host, DesdeEmail: servidor?.DesdeEmail });
+    return servidor;
 };
 
 export const emailServer_upsert = async (idEmpresa: number, data: Partial<EmailServer>) => {


### PR DESCRIPTION
## Summary
- log server lookup and result in `emailServer_getByEmpresa`

## Testing
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_688ffc11e678832aae831c14fdd9213e