### PR TITLE
chore: add debug logs to email template helper

### DIFF
--- a/src/helpers/emailTemplates.ts
+++ b/src/helpers/emailTemplates.ts
@@ -5,12 +5,16 @@ export const renderEmailTemplate = async (
   valores: Record<string, string>,
   idTemplate?: number
 ): Promise<{ asunto: string; cuerpo: string } | null> => {
+  console.log('[EmailTemplate] Código', codigo, 'idTemplate', idTemplate);
   const template = idTemplate
     ? await template_getById(idTemplate)
     : await template_getByTipo(codigo);
   if (!template || !template.Activo) {
     return null;
   }
+
+  console.log('[EmailTemplate] Título original', template.Titulo);
+  console.log('[EmailTemplate] Variables', valores);
   
   // Usar Titulo como asunto y Cuerpo como cuerpo del mensaje
   let asunto = template.Titulo || 'Sin asunto';
@@ -22,6 +26,9 @@ export const renderEmailTemplate = async (
     asunto = asunto.replace(regex, value);
     cuerpo = cuerpo.replace(regex, value);
   }
-  
+
+  console.log('[EmailTemplate] Asunto final', asunto);
+  console.log('[EmailTemplate] Cuerpo preview', cuerpo.slice(0, 100));
+
   return { asunto, cuerpo };
 }


### PR DESCRIPTION
## Summary
- add detailed logging to email template helper

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ffddb9b7c832a8ad9d50519dcb357