### PR TITLE
refactor: align email server from field

### DIFF
--- a/src/DALC/emailServers.dalc.ts
+++ b/src/DALC/emailServers.dalc.ts
@@ -4,7 +4,7 @@ import { EmailServer } from "../entities/EmailServer";
 export const emailServer_getByEmpresa = async (idEmpresa: number) => {
     console.log('[EmailServerDALC] Buscando servidor para empresa', idEmpresa);
     const servidor = await getRepository(EmailServer).findOne({ where: { IdEmpresa: idEmpresa } as any });
-    console.log('[EmailServerDALC] Servidor encontrado', { Id: servidor?.Id, Host: servidor?.Host, DesdeEmail: servidor?.DesdeEmail });
+    console.log('[EmailServerDALC] Servidor encontrado', { Id: servidor?.Id, Host: servidor?.Host, FromEmail: servidor?.FromEmail });
     return servidor;
 };
 

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -39,7 +39,7 @@ export class EmailService {
       Seguro: false,
       Usuario: '',
       Password: '',
-      DesdeEmail: 'noreply@example.com',
+      FromEmail: 'noreply@example.com',
       DesdeNombre: 'Sistema'
     }
 
@@ -50,7 +50,7 @@ export class EmailService {
     const secure = cfg.Seguro ?? cfg.Secure ?? false
     const user = cfg.Usuario ?? cfg.Username ?? ''
     const pass = cfg.Password ?? ''
-    const fromEmail = options.emailRemitente || cfg.DesdeEmail || cfg.FromEmail
+    const fromEmail = options.emailRemitente || cfg.FromEmail
     const fromName = options.nombreRemitente || cfg.DesdeNombre || cfg.FromName
 
     console.log('[EmailService] SMTP server', {


### PR DESCRIPTION
## Summary
- log email server FromEmail instead of obsolete DesdeEmail
- remove legacy DesdeEmail references in email service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*
- `npm run build` *(fails: Property 'Id' does not exist on type 'MailSaliente')*


------
https://chatgpt.com/codex/tasks/task_e_68900309506c832a8f2982a9c13a2611